### PR TITLE
Ignore invalid semver format from solc

### DIFF
--- a/compilation/platforms/solc.go
+++ b/compilation/platforms/solc.go
@@ -35,7 +35,7 @@ func GetSystemSolcVersion() (*semver.Version, error) {
 	}
 
 	// Parse the compiler version out of the output
-	exp := regexp.MustCompile("\\d+\\.\\d+\\.\\d+\\S*")
+	exp := regexp.MustCompile("\\d+\\.\\d+\\.\\d+")
 	versionStr := exp.FindString(string(out))
 	if versionStr == "" {
 		return nil, errors.New("could not parse solc version using 'solc --version'")


### PR DESCRIPTION
Solidity returns a version that isn't valid semver on some platforms. This applies a fix to ignore invalid pre-release tags before parsing the version.