### PR TITLE
Add slither as a dependency to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          # Install from github until the following is released: https://github.com/crytic/crytic-compile/pull/309
           pip3 install solc-select
           pip3 install slither-analyzer
 


### PR DESCRIPTION
Slither will be a dependency after the merging of #69

Added a single command to `ci.yml` to ensure it is installed before the running of the test suite.