### PR TITLE
Update CI to automate build artifact uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ concurrency:
 jobs:
   build:
     needs: [lint, test]
-    name: Build (${{ matrix.environment }})
     strategy:
       matrix:
         environment: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
This PR closes #106 

This small PR introduces the following:
1. Introduces a `build` step in the CI that will `go build medusa` for all three major OS environments and uploads each OS's build artifact to the workflow run. This is especially useful for quickly uploading artifacts during releases.
2. The workflow will now only run when pushes are made to the `master` branch, when PRs are made to `master`, or when manually triggered.

I have no idea if the code written in the `.yml` file is hot garbage or not. Maybe there is a better/faster/more memory-efficient way to build and upload artifacts than the way I did. I sort of used Echidna's CI as inspiration and went from there.

We should revisit this down the line but I think it is good enough for now.