### PR TITLE
Fix panics

### DIFF
--- a/fuzzing/calls/call_message_abi_values.go
+++ b/fuzzing/calls/call_message_abi_values.go
@@ -8,6 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// UNRESOLVED_METHOD describes the constant that is returned when we are unable to resolve an abi.Method at runtime.
+// This primarily may occur when replaying a corpus and the ABI of a contract has changed between runs.
+const UNRESOLVED_METHOD = "UNRESOLVED_METHOD"
+
 // CallMessageDataAbiValues describes a CallMessage Data field which is represented by ABI input argument values.
 // This is represented at runtime by an abi.Method and its input values.
 // Note: The data may be serialized. When deserializing, the Resolve method must be called to resolve the abi.Method
@@ -87,9 +91,10 @@ func (d *CallMessageDataAbiValues) Resolve(contractAbi abi.ABI) error {
 // Pack packs all the ABI argument InputValues into call data for the relevant Method it targets. If this was
 // deserialized, Resolve must be called first to resolve necessary runtime data (such as the Method).
 func (d *CallMessageDataAbiValues) Pack() ([]byte, error) {
-	// We must have set an ABI method at runtime to serialize this.
+	// If we do not have an ABI method at runtime to serialize this, we will return a []byte of UNRESOLVED_METHOD
+	// This should only happen when the corpus is being replayed and the ABI of a contract has changed between runs
 	if d.Method == nil {
-		return nil, fmt.Errorf("ABI call data packing failed, method definition was not set at runtime")
+		return []byte(UNRESOLVED_METHOD), nil
 	}
 
 	// If our ABI method was not set, we can't serialize our data.

--- a/fuzzing/calls/call_message_abi_values.go
+++ b/fuzzing/calls/call_message_abi_values.go
@@ -8,10 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// UNRESOLVED_METHOD describes the constant that is returned when we are unable to resolve an abi.Method at runtime.
-// This primarily may occur when replaying a corpus and the ABI of a contract has changed between runs.
-const UNRESOLVED_METHOD = "UNRESOLVED_METHOD"
-
 // CallMessageDataAbiValues describes a CallMessage Data field which is represented by ABI input argument values.
 // This is represented at runtime by an abi.Method and its input values.
 // Note: The data may be serialized. When deserializing, the Resolve method must be called to resolve the abi.Method
@@ -91,10 +87,10 @@ func (d *CallMessageDataAbiValues) Resolve(contractAbi abi.ABI) error {
 // Pack packs all the ABI argument InputValues into call data for the relevant Method it targets. If this was
 // deserialized, Resolve must be called first to resolve necessary runtime data (such as the Method).
 func (d *CallMessageDataAbiValues) Pack() ([]byte, error) {
-	// If we do not have an ABI method at runtime to serialize this, we will return a []byte of UNRESOLVED_METHOD
-	// This should only happen when the corpus is being replayed and the ABI of a contract has changed between runs
+	// If we do not have an ABI method at runtime to serialize this, we will return an error.
+	// This may happen when the corpus is being replayed and the ABI of a contract has changed between runs.
 	if d.Method == nil {
-		return []byte(UNRESOLVED_METHOD), nil
+		return nil, fmt.Errorf("ABI call data packing failed, method definition was not set at runtime")
 	}
 
 	// If our ABI method was not set, we can't serialize our data.

--- a/fuzzing/test_case_property.go
+++ b/fuzzing/test_case_property.go
@@ -47,7 +47,7 @@ func (t *PropertyTestCase) Message() string {
 		// If an execution trace is attached then add it to the message
 		if t.propertyTestTrace != nil {
 			// TODO: Improve formatting in logging PR
-			msg = fmt.Sprintf("%s\n Property test execution trace:\n%s", msg, t.propertyTestTrace.String())
+			msg += fmt.Sprintf("\nProperty test execution trace:\n%s", t.propertyTestTrace.String())
 		}
 		return msg
 	}

--- a/fuzzing/test_case_property.go
+++ b/fuzzing/test_case_property.go
@@ -38,16 +38,18 @@ func (t *PropertyTestCase) Name() string {
 func (t *PropertyTestCase) Message() string {
 	// If the test failed, return a failure message.
 	if t.Status() == TestCaseStatusFailed {
-		return fmt.Sprintf(
-			"Test \"%s.%s\" failed after the following call sequence:\n%s\n"+
-				"Property test \"%s.%s\" execution:\n%s",
+		msg := fmt.Sprintf(
+			"Property test \"%s.%s\" failed after the following call sequence:\n%s",
 			t.targetContract.Name(),
 			t.targetMethod.Sig,
 			t.CallSequence().String(),
-			t.targetContract.Name(),
-			t.targetMethod.Sig,
-			t.propertyTestTrace.String(),
 		)
+		// If an execution trace is attached then add it to the message
+		if t.propertyTestTrace != nil {
+			// TODO: Improve formatting in logging PR
+			msg = fmt.Sprintf("%s\n Property test execution trace:\n%s", msg, t.propertyTestTrace.String())
+		}
+		return msg
 	}
 	return ""
 }


### PR DESCRIPTION
This PR closes #123 and closes #124.

The fix for #123 was as follows:
- When crafting `PropertyTestCase.Message`, we just check to see if the `propertyTestTrace` is nil or not. If it is not nil, we attach it to the msg

The fix for #124 was as follows:
- When packing `CallMessageDataAbiValues`, we check to see if `d.Method` is nil. If it is `nil`, then we return back a fixed `UNRESOLVED_METHOD` value. Note that `d.Method` is nil at runtime only if we are replaying the corpus. It cannot happen when creating a new `CallMessage` since that would mean that `CallSequenceGenerator.generateNewElement` would return a nil `selectedMethod` which is not possible...i believe.