### PR TITLE
Fix array/slice mutation panic

### DIFF
--- a/fuzzing/valuegeneration/abi_values_test.go
+++ b/fuzzing/valuegeneration/abi_values_test.go
@@ -126,8 +126,8 @@ func getTestABIArguments() abi.Arguments {
 		// Alias our arg so when we get a pointer to it, we don't cause a memory leak in this loop
 		basicArg := basicArg
 
-		// Add a slice/array of this basic type.
-		args = append(args,
+		// Define our array arguments.
+		arrayArgs := abi.Arguments{
 			abi.Argument{
 				Name: fmt.Sprintf("testSlice (%v)", basicArg.Type.GetType().String()),
 				Type: abi.Type{
@@ -154,7 +154,45 @@ func getTestABIArguments() abi.Arguments {
 				},
 				Indexed: false,
 			},
-		)
+		}
+
+		// Add slice/array for our basic types.
+		args = append(args, arrayArgs...)
+
+		// Now for those slices/arrays, we create nested ones
+		for _, arrayArg := range arrayArgs {
+			arrayArg := arrayArg
+
+			// Add nested slice/arrays.
+			args = append(args,
+				abi.Argument{
+					Name: fmt.Sprintf("testSlice (%v)", arrayArg.Type.GetType().String()),
+					Type: abi.Type{
+						Elem:          &arrayArg.Type,
+						Size:          0,
+						T:             abi.SliceTy,
+						TupleRawName:  "",
+						TupleElems:    nil,
+						TupleRawNames: nil,
+						TupleType:     nil,
+					},
+					Indexed: false,
+				},
+				abi.Argument{
+					Name: fmt.Sprintf("testArray (%v)", arrayArg.Type.GetType().String()),
+					Type: abi.Type{
+						Elem:          &arrayArg.Type,
+						Size:          3,
+						T:             abi.ArrayTy,
+						TupleRawName:  "",
+						TupleElems:    nil,
+						TupleRawNames: nil,
+						TupleType:     nil,
+					},
+					Indexed: false,
+				},
+			)
+		}
 	}
 
 	// TODO: Add tuple argument.
@@ -243,7 +281,7 @@ func TestABIGenerationAndMutation(t *testing.T) {
 	// Loop for each input argument
 	for _, arg := range args {
 		// Test each argument round trip serialization with different generated values (iterate a number of times).
-		for i := 0; i < 50; i++ {
+		for i := 0; i < 5; i++ {
 			// Generate a value for this argument
 			value := GenerateAbiValue(valueGenerator, &arg.Type)
 

--- a/utils/reflectionutils/reflected_type_utils.go
+++ b/utils/reflectionutils/reflected_type_utils.go
@@ -35,15 +35,15 @@ func CopyReflectedType(reflectedValue reflect.Value) reflect.Value {
 	case reflect.Slice:
 		elementType := reflectedValue.Type().Elem()
 		newSlice := reflect.MakeSlice(reflect.SliceOf(elementType), reflectedValue.Len(), reflectedValue.Cap())
-		if reflect.Copy(newSlice, reflectedValue) != reflectedValue.Len() {
-			panic("failed to copy reflected value, unexpected resulting slice length")
+		for i := 0; i < reflectedValue.Len(); i++ {
+			newSlice.Index(i).Set(reflect.ValueOf(reflectedValue.Index(i).Interface()))
 		}
 		return newSlice
 	case reflect.Array:
 		arrayType := reflect.ArrayOf(reflectedValue.Len(), reflectedValue.Type().Elem())
 		newArray := reflect.New(arrayType).Elem()
-		if reflect.Copy(newArray, reflectedValue) != reflectedValue.Len() {
-			panic("failed to copy reflected value, unexpected resulting array length")
+		for i := 0; i < reflectedValue.Len(); i++ {
+			newArray.Index(i).Set(reflect.ValueOf(reflectedValue.Index(i).Interface()))
 		}
 		return newArray
 	case reflect.Struct:


### PR DESCRIPTION
This fixes a panic encountered when mutating a nested array/slice type, where `reflectionutils` was not properly copying a nested array during mutation, causing some `*big.Int` types inside of a nested array to report as `*big.Int(nil)` rather than their actual values.

This also updates the ABI value generator tests with nested array types of every kind and lowers the test iteration count to avoid the test being too expensive.

This resolves the issue @ggrieco-tob pointed out when running medusa within one of our tools.

An example contract which triggers this panic is provided below:
```
contract TestContract {
	function test_uint256_array_1x2_one(uint256[1][2] memory value) public {
        assert(keccak256(abi.encode(value)) != bytes32(0xcc69885fda6bcc1a4ace058b4a62bf5e179ea78fd58a1ccd71c22cc9b688792f));
    }
}
```