### PR TITLE
Fix internal library event emissions in ExecutionTrace

### DIFF
--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -201,8 +201,9 @@ func (t *ExecutionTrace) generateEventEmittedString(callFrame *CallFrame, eventL
 	// Try to unpack our event data
 	event, eventInputValues := abiutils.UnpackEventAndValues(callFrame.CodeContractAbi, eventLog)
 	if event == nil {
-		// TODO: If we couldn't resolve the event, it comes from a library. Temporarily, we just try to resolve the
-		//  event from all contracts, until we can associate which contracts actually represent relevant libraries.
+		// If we couldn't resolve the event from our immediate contract ABI, it may come from a library.
+		// TODO: Temporarily, we fix this by trying to resolve the event from any contracts definition. A future
+		//  fix should include only checking relevant libraries associated with the contract.
 		for _, contract := range t.contractDefinitions {
 			event, eventInputValues = abiutils.UnpackEventAndValues(&contract.CompiledContract().Abi, eventLog)
 			if event != nil {

--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"github.com/crytic/medusa/compilation/abiutils"
+	"github.com/crytic/medusa/fuzzing/contracts"
 	"github.com/crytic/medusa/fuzzing/valuegeneration"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
@@ -17,12 +18,17 @@ type ExecutionTrace struct {
 	// TopLevelCallFrame refers to the root call frame, the first EVM call scope entered when an externally-owned
 	// address calls upon a contract.
 	TopLevelCallFrame *CallFrame
+
+	// ContractDefinitions represents the known contract definitions at the time of tracing. This is used to help
+	// obtain any additional information regarding execution.
+	ContractDefinitions contracts.Contracts
 }
 
 // newExecutionTrace creates and returns a new ExecutionTrace, to be used by the ExecutionTracer.
-func newExecutionTrace() *ExecutionTrace {
+func newExecutionTrace(contracts contracts.Contracts) *ExecutionTrace {
 	return &ExecutionTrace{
-		TopLevelCallFrame: nil,
+		TopLevelCallFrame:   nil,
+		ContractDefinitions: contracts,
 	}
 }
 
@@ -194,6 +200,18 @@ func (t *ExecutionTrace) generateEventEmittedString(callFrame *CallFrame, eventL
 
 	// Try to unpack our event data
 	event, eventInputValues := abiutils.UnpackEventAndValues(callFrame.CodeContractAbi, eventLog)
+	if event == nil {
+		// TODO: If we couldn't resolve the event, it comes from a library. Temporarily, we just try to resolve the
+		//  event from all contracts, until we can associate which contracts actually represent relevant libraries.
+		for _, contract := range t.ContractDefinitions {
+			event, eventInputValues = abiutils.UnpackEventAndValues(&contract.CompiledContract().Abi, eventLog)
+			if event != nil {
+				break
+			}
+		}
+	}
+
+	// If we resolved an event definition and unpacked data.
 	if event != nil {
 		// Format the values as a comma-separated string
 		encodedEventValuesString, err := valuegeneration.EncodeABIArgumentsToString(event.Inputs, eventInputValues)

--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -19,16 +19,16 @@ type ExecutionTrace struct {
 	// address calls upon a contract.
 	TopLevelCallFrame *CallFrame
 
-	// ContractDefinitions represents the known contract definitions at the time of tracing. This is used to help
+	// contractDefinitions represents the known contract definitions at the time of tracing. This is used to help
 	// obtain any additional information regarding execution.
-	ContractDefinitions contracts.Contracts
+	contractDefinitions contracts.Contracts
 }
 
 // newExecutionTrace creates and returns a new ExecutionTrace, to be used by the ExecutionTracer.
 func newExecutionTrace(contracts contracts.Contracts) *ExecutionTrace {
 	return &ExecutionTrace{
 		TopLevelCallFrame:   nil,
-		ContractDefinitions: contracts,
+		contractDefinitions: contracts,
 	}
 }
 
@@ -203,7 +203,7 @@ func (t *ExecutionTrace) generateEventEmittedString(callFrame *CallFrame, eventL
 	if event == nil {
 		// TODO: If we couldn't resolve the event, it comes from a library. Temporarily, we just try to resolve the
 		//  event from all contracts, until we can associate which contracts actually represent relevant libraries.
-		for _, contract := range t.ContractDefinitions {
+		for _, contract := range t.contractDefinitions {
 			event, eventInputValues = abiutils.UnpackEventAndValues(&contract.CompiledContract().Abi, eventLog)
 			if event != nil {
 				break

--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -77,7 +77,7 @@ func (t *ExecutionTracer) Trace() *ExecutionTrace {
 func (t *ExecutionTracer) CaptureTxStart(gasLimit uint64) {
 	// Reset our capture state
 	t.callDepth = 0
-	t.trace = newExecutionTrace()
+	t.trace = newExecutionTrace(t.contractDefinitions)
 	t.currentCallFrame = nil
 	t.onNextCaptureState = nil
 }

--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -324,7 +324,7 @@ func TestExecutionTraces(t *testing.T) {
 	expectedMessagesPerTest := map[string][]string{
 		"testdata/contracts/execution_tracing/call_and_deployment_args.sol": {"Hello from deployment args!", "Hello from call args!"},
 		"testdata/contracts/execution_tracing/cheatcodes.sol":               {"StdCheats.toString(true)"},
-		"testdata/contracts/execution_tracing/event_emission.sol":           {"TestEvent", "TestIndexedEvent", "TestMixedEvent", "Hello from event args!"},
+		"testdata/contracts/execution_tracing/event_emission.sol":           {"TestEvent", "TestIndexedEvent", "TestMixedEvent", "Hello from event args!", "Hello from library event args!"},
 		"testdata/contracts/execution_tracing/proxy_call.sol":               {"TestContract -> InnerDeploymentContract.setXY", "Hello from proxy call args!"},
 		"testdata/contracts/execution_tracing/revert_custom_error.sol":      {"CustomError", "Hello from a custom error!"},
 		"testdata/contracts/execution_tracing/revert_reasons.sol":           {"RevertingContract was called and reverted."},

--- a/fuzzing/testdata/contracts/execution_tracing/event_emission.sol
+++ b/fuzzing/testdata/contracts/execution_tracing/event_emission.sol
@@ -1,4 +1,12 @@
-// This contract ensures the fuzzer's execution tracing can obtain event emissions.
+// This test ensures the fuzzer's execution tracing can obtain event emissions.
+library Logger {
+    event TestLibraryEvent(string s);
+
+    function log(string memory s) internal {
+        emit TestLibraryEvent(s);
+    }
+}
+
 contract TestContract {
     uint x;
     uint y;
@@ -15,6 +23,7 @@ contract TestContract {
         emit TestEvent(value);
         emit TestIndexedEvent(value);
         emit TestMixedEvent(msg.sender, value, 7, "Hello from event args!");
+        Logger.log("Hello from library event args!");
         assert(x % 2 == 0);
     }
 }


### PR DESCRIPTION
This PR closes #131 with a temporary fix.

The issue was that events emitted through internal libraries were not being resolved. This provides a temp fix where if the immediate contract ABI does not contain the event definition, all contract definitions will be iterated over to find a matching event.

A future fix should include discovering associations between contracts and libraries and only resolving the event from relevant associated libraries.

However, for now, I'm confident this should work without any practical issues popping up.

Changes:
- `ExecutionTrace` now stores a reference to all contract definitions
- `ExecutionTracer` initializes `ExecutionTrace` with all contract definitions
- `ExecutionTrace` uses all contract definitions as a backup to try and resolve _any_ event which matches the current one, if the immediate contract ABI did not contain the correct event definition.
- Updated event emission test to include use of an internal library.