### PR TITLE
ci: pin node version to 18.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,11 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "^1.18.1"
-          
+
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.5
-          
+          node-version: 18.15
+
       - name: Install Node dependencies
         run: npm install -g hardhat truffle
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,11 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "^1.18.1"
-
+          
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.5
+          
       - name: Install Node dependencies
         run: npm install -g hardhat truffle
 


### PR DESCRIPTION
Fixes flaky hardhat compilation until a node release is made https://github.com/NomicFoundation/hardhat/issues/3877