### PR TITLE
Add Nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,14 +13,16 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+*node_modules/
 
 # Goland project dir
 .idea/
-
-*node_modules/
 
 # Medusa binary
 medusa
 
 # Medusa docs
 docs/book
+
+# Build results
+result

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,16 @@ To run
 
 - Ensure JSON keys are `camelCase` rather than `snake_case`, where possible.
 
+### Nix considerations
+
+- If any dependencies are added or removed, the `vendorHash` property in ./flake.nix will need to be updated. To do so, run `nix build`. If it works, you're good to go. If a change is required, you'll see an error that looks like the following. Replace the `specified` value of `vendorHash` in the medusa package of flake.nix with what nix actually `got`.
+
+```
+error: hash mismatch in fixed-output derivation '/nix/store/sfgmkr563pzyxzllpmwxdbdxgrav8y1p-medusa-0.1.8-go-modules.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-12Xkg5dzA83HQ2gMngXoLgu1c9KGSL6ly5Qz/o8U++8=
+```
+
 ## License
 
 The license for this software can be found [here](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The master branch can be installed using the following command:
 brew install --HEAD medusa
 ```
 
-For more information on building from source or obtaining binaries for Windows and Linux, please refer to the [installation guide](./docs/src/getting_started/installation.md).
+For more information on building from source, using nix, or obtaining binaries for Windows and Linux, please refer to the [installation guide](./docs/src/getting_started/installation.md).
 
 ## Contributing
 

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -22,6 +22,27 @@ Run the following command to install `medusa`:
 brew install medusa
 ```
 
+## Installing with Nix
+
+### Prerequisites
+
+Make sure nix is installed and that `nix-command` and `flake` features are enabled. The [Determinate Systems nix-installer](https://determinate.systems/nix-installer/) will automatically enable these features and is the recommended approach. If nix is already installed without these features enabled, run the following commands.
+
+```
+mkdir -p ~/.config/nix
+echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf
+```
+
+### Build `medusa`
+
+`nix build` will build medusa and wire up independent copies of required dependencies. The resulting binary can be found at `./result/bin/medusa`
+
+### Install `medusa`
+
+After building, you can add the build result to your PATH using nix profiles by running the following command:
+
+`nix profile install ./result`
+
 ## Building from source
 
 ### Prerequisites

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -17,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675061157,
-        "narHash": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA=",
+        "lastModified": 1735669367,
+        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-22.11",
+        "ref": "nixos-24.11",
         "type": "indirect"
       }
     },
@@ -34,6 +37,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1675061157,
+        "narHash": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Medusa smart-contract fuzzer";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-22.11";
+    nixpkgs.url = "nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -12,7 +12,7 @@
         pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
         pyCommon = {
           format = "pyproject";
-          nativeBuildInputs = with pkgs.python39Packages; [ pythonRelaxDepsHook ];
+          nativeBuildInputs = with pkgs.python3Packages; [ pythonRelaxDepsHook ];
           pythonRelaxDeps = true;
           doCheck = false;
         };
@@ -21,28 +21,28 @@
 
         packages = rec {
 
-          solc-select = pkgs.python39Packages.buildPythonPackage (pyCommon // {
+          solc-select = pkgs.python3Packages.buildPythonPackage (pyCommon // {
             pname = "solc-select";
-            version = "1.0.3";
+            version = "1.0.4";
             src = builtins.fetchGit {
-              url = "git+ssh://git@github.com/crytic/solc-select";
-              rev = "97f160611c39d46e27d6f44a5a61344e6218d584";
+              url = "https://github.com/crytic/solc-select.git";
+              rev = "8072a3394bdc960c0f652fb72e928a7eae3631da";
             };
-            propagatedBuildInputs = with pkgs.python39Packages; [
+            propagatedBuildInputs = with pkgs.python3Packages; [
               packaging
               setuptools
               pycryptodome
             ];
           });
 
-          crytic-compile = pkgs.python39Packages.buildPythonPackage (pyCommon // rec {
+          crytic-compile = pkgs.python3Packages.buildPythonPackage (pyCommon // rec {
             pname = "crytic-compile";
-            version = "0.3.1";
+            version = "0.3.7";
             src = builtins.fetchGit {
-              url = "git+ssh://git@github.com/crytic/crytic-compile";
-              rev = "10104f33f593ab82ba5780a5fe8dd26385acd1c1";
+              url = "https://github.com/crytic/crytic-compile.git";
+              rev = "20df04f37af723eaa7fa56dc2c80169776f3bc4d";
             };
-            propagatedBuildInputs = with pkgs.python39Packages; [
+            propagatedBuildInputs = with pkgs.python3Packages; [
               cbor2
               pycryptodome
               setuptools
@@ -50,34 +50,31 @@
             ];
           });
 
-          slither = pkgs.python39Packages.buildPythonPackage (pyCommon // rec {
+          slither = pkgs.python3Packages.buildPythonPackage (pyCommon // rec {
             pname = "slither";
-            version = "0.9.3";
+            version = "0.10.4";
             format = "pyproject";
             src = builtins.fetchGit {
-              url = "git+ssh://git@github.com/crytic/slither";
-              rev = "e6b8af882c6419a9119bec5f4cfff93985a92f4e";
+              url = "https://github.com/crytic/slither.git";
+              rev = "aeeb2d368802844733671e35200b30b5f5bdcf5c";
             };
-            nativeBuildInputs = with pkgs.python39Packages; [ pythonRelaxDepsHook ];
+            nativeBuildInputs = with pkgs.python3Packages; [ pythonRelaxDepsHook ];
             pythonRelaxDeps = true;
             doCheck = false;
-            propagatedBuildInputs = with pkgs.python39Packages; [
+            propagatedBuildInputs = with pkgs.python3Packages; [
               packaging
               prettytable
               pycryptodome
               packages.crytic-compile
+              web3
             ];
-            postPatch = ''
-              echo "web3 dependency depends on ipfs which is bugged, removing it from the listed deps"
-              sed -i 's/"web3>=6.0.0",//' setup.py
-            '';
           });
 
           medusa = pkgs.buildGoModule {
             pname = "medusa";
-            version = "0.1.0"; # from cmd/root.go
+            version = "0.1.8"; # from cmd/root.go
             src = ./.;
-            vendorSha256 = "sha256-odBzty8wgFfdSF18D15jWtUNeQPJ7bkt9k5dx+8EFb4=";
+            vendorHash = "sha256-12Xkg5dzA83HQ2gMngXoLgu1c9KGSL6ly5Qz/o8U++8=";
             nativeBuildInputs = [
               packages.crytic-compile
               pkgs.solc
@@ -114,7 +111,6 @@
               go-tools
               gopls
               go-outline
-              gocode
               gopkgs
               gocode-gomod
               godef

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,128 @@
+{
+  description = "Medusa smart-contract fuzzer";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+        pyCommon = {
+          format = "pyproject";
+          nativeBuildInputs = with pkgs.python39Packages; [ pythonRelaxDepsHook ];
+          pythonRelaxDeps = true;
+          doCheck = false;
+        };
+      in
+      rec {
+
+        packages = rec {
+
+          solc-select = pkgs.python39Packages.buildPythonPackage (pyCommon // {
+            pname = "solc-select";
+            version = "1.0.3";
+            src = builtins.fetchGit {
+              url = "git+ssh://git@github.com/crytic/solc-select";
+              rev = "97f160611c39d46e27d6f44a5a61344e6218d584";
+            };
+            propagatedBuildInputs = with pkgs.python39Packages; [
+              packaging
+              setuptools
+              pycryptodome
+            ];
+          });
+
+          crytic-compile = pkgs.python39Packages.buildPythonPackage (pyCommon // rec {
+            pname = "crytic-compile";
+            version = "0.3.1";
+            src = builtins.fetchGit {
+              url = "git+ssh://git@github.com/crytic/crytic-compile";
+              rev = "10104f33f593ab82ba5780a5fe8dd26385acd1c1";
+            };
+            propagatedBuildInputs = with pkgs.python39Packages; [
+              cbor2
+              pycryptodome
+              setuptools
+              packages.solc-select
+            ];
+          });
+
+          slither = pkgs.python39Packages.buildPythonPackage (pyCommon // rec {
+            pname = "slither";
+            version = "0.9.3";
+            format = "pyproject";
+            src = builtins.fetchGit {
+              url = "git+ssh://git@github.com/crytic/slither";
+              rev = "e6b8af882c6419a9119bec5f4cfff93985a92f4e";
+            };
+            nativeBuildInputs = with pkgs.python39Packages; [ pythonRelaxDepsHook ];
+            pythonRelaxDeps = true;
+            doCheck = false;
+            propagatedBuildInputs = with pkgs.python39Packages; [
+              packaging
+              prettytable
+              pycryptodome
+              packages.crytic-compile
+            ];
+            postPatch = ''
+              echo "web3 dependency depends on ipfs which is bugged, removing it from the listed deps"
+              sed -i 's/"web3>=6.0.0",//' setup.py
+            '';
+          });
+
+          medusa = pkgs.buildGoModule {
+            pname = "medusa";
+            version = "0.1.0"; # from cmd/root.go
+            src = ./.;
+            vendorSha256 = "sha256-odBzty8wgFfdSF18D15jWtUNeQPJ7bkt9k5dx+8EFb4=";
+            nativeBuildInputs = [
+              packages.crytic-compile
+              pkgs.solc
+              pkgs.nodejs
+            ];
+            doCheck = false; # tests require `npm install` which can't run in hermetic build env
+          };
+
+          default = medusa;
+
+        };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.medusa}/bin/medusa";
+          };
+        };
+
+        devShells = {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              packages.medusa
+              bashInteractive
+              # runtime dependencies
+              packages.crytic-compile
+              packages.slither
+              solc
+              # test dependencies
+              nodejs
+              # go development
+              go
+              gotools
+              go-tools
+              gopls
+              go-outline
+              gocode
+              gopkgs
+              gocode-gomod
+              godef
+              golint
+            ];
+          };
+        };
+
+      }
+    );
+}


### PR DESCRIPTION
Once merged to the default branch, this PR should allow anyone with nix installed to run `nix run github:crytic/medusa` to use the medusa tool without installing anything globally. Kind of like a single-serving virtualenv. The first time this is run, it'll take some time as medusa's dependencies (eg `slither`) are downloaded & the project is built, but subsequent runs will start almost instantly without requiring any further downloads. [More info re `nix run`](https://determinate.systems/posts/nix-run).

Allows global installation of medusa with: `nix build && nix-env -i ./result`. This `medusa` installation is hooked up to a new copy of required dependencies, so it'll take care of the slither dependency if not already present but w/out any risk of conflict w existing global `slither` installation.

Also provides a developer environment via `nix develop` which opens a shell that includes basic golang tools & other dependencies needed to build & run tests.

This is entirely opt-in, it uses the rest of the repo's config (eg `go.mod`) rather than attempting to replace it. If you don't want to fiddle with `nix`, then you can ignore these new files & do the same thing you've always done.