### PR TITLE
Fix addr cheatcode

### DIFF
--- a/chain/cheat_codes.go
+++ b/chain/cheat_codes.go
@@ -341,7 +341,10 @@ func getStandardCheatCodeContract(tracer *cheatCodeTracer) (*CheatCodeContract, 
 	contract.addMethod("addr", abi.Arguments{{Type: typeUint256}}, abi.Arguments{{Type: typeAddress}},
 		func(tracer *cheatCodeTracer, inputs []any) ([]any, *cheatCodeRawReturnData) {
 			// Using TOECDSAUnsafe b/c the private key is guaranteed to be of length 256 bits, at most
-			privateKey := crypto.ToECDSAUnsafe(inputs[0].(*big.Int).Bytes())
+			privateKey, err := crypto.ToECDSA(inputs[0].(*big.Int).Bytes())
+			if err != nil {
+				return nil, cheatCodeRevertData([]byte("addr: invalid private key"))
+			}
 
 			// Get ECDSA public key
 			publicKey := privateKey.Public().(*ecdsa.PublicKey)


### PR DESCRIPTION
The addr cheatcode used `ToECDSAUnsafe` which was a dumb idea on my part instead of `ToECDSA`. This fixes that and throws an error if the private key provided is invalid.