### PR TITLE
fix isPropertyTest function

### DIFF
--- a/fuzzing/test_case_assertion.go
+++ b/fuzzing/test_case_assertion.go
@@ -11,10 +11,14 @@ import (
 
 // AssertionTestCase describes a test being run by a AssertionTestCaseProvider.
 type AssertionTestCase struct {
-	status         TestCaseStatus
+	// status describes the status of the test case
+	status TestCaseStatus
+	// targetContract describes the target contract where the test case was found
 	targetContract *fuzzerTypes.Contract
-	targetMethod   abi.Method
-	callSequence   *calls.CallSequence
+	// targetMethod describes the target method for the test case
+	targetMethod abi.Method
+	// callSequence describes the call sequence that broke the assertion
+	callSequence *calls.CallSequence
 }
 
 // Status describes the TestCaseStatus used to define the current state of the test.

--- a/fuzzing/test_case_assertion_provider.go
+++ b/fuzzing/test_case_assertion_provider.go
@@ -118,7 +118,7 @@ func (t *AssertionTestCaseProvider) onFuzzerStarting(event FuzzerStartingEvent) 
 	return nil
 }
 
-// onFuzzerStarting is the event handler triggered when the Fuzzer is stopping the fuzzing campaign and all workers
+// onFuzzerStopping is the event handler triggered when the Fuzzer is stopping the fuzzing campaign and all workers
 // have been destroyed. It clears state tracked for each FuzzerWorker and sets test cases in "running" states to
 // "passed".
 func (t *AssertionTestCaseProvider) onFuzzerStopping(event FuzzerStoppingEvent) error {

--- a/fuzzing/test_case_property.go
+++ b/fuzzing/test_case_property.go
@@ -11,10 +11,15 @@ import (
 
 // PropertyTestCase describes a test being run by a PropertyTestCaseProvider.
 type PropertyTestCase struct {
-	status            TestCaseStatus
-	targetContract    *fuzzerTypes.Contract
-	targetMethod      abi.Method
-	callSequence      *calls.CallSequence
+	// status describes the status of the test case
+	status TestCaseStatus
+	// targetContract describes the target contract where the test case was found
+	targetContract *fuzzerTypes.Contract
+	// targetMethod describes the target method for the test case
+	targetMethod abi.Method
+	// callSequence describes the call sequence that broke the property
+	callSequence *calls.CallSequence
+	// propertyTestTrace describes the execution trace when running the callSequence
 	propertyTestTrace *executiontracer.ExecutionTrace
 }
 

--- a/fuzzing/test_case_property_provider.go
+++ b/fuzzing/test_case_property_provider.go
@@ -175,7 +175,7 @@ func (t *PropertyTestCaseProvider) onFuzzerStarting(event FuzzerStartingEvent) e
 	return nil
 }
 
-// onFuzzerStarting is the event handler triggered when the Fuzzer is stopping the fuzzing campaign and all workers
+// onFuzzerStopping is the event handler triggered when the Fuzzer is stopping the fuzzing campaign and all workers
 // have been destroyed. It clears state tracked for each FuzzerWorker and sets test cases in "running" states to
 // "passed".
 func (t *PropertyTestCaseProvider) onFuzzerStopping(event FuzzerStoppingEvent) error {
@@ -247,7 +247,7 @@ func (t *PropertyTestCaseProvider) onWorkerDeployedContractAdded(event FuzzerWor
 	return nil
 }
 
-// onWorkerDeployedContractAdded is the event handler triggered when a FuzzerWorker detects that a previously deployed
+// onWorkerDeployedContractDeleted is the event handler triggered when a FuzzerWorker detects that a previously deployed
 // contract no longer exists on its underlying chain. It ensures any property test methods which the deployed contract
 // contained are no longer tracked by the provider for testing.
 func (t *PropertyTestCaseProvider) onWorkerDeployedContractDeleted(event FuzzerWorkerContractDeletedEvent) error {

--- a/fuzzing/test_case_property_provider.go
+++ b/fuzzing/test_case_property_provider.go
@@ -68,7 +68,7 @@ func (t *PropertyTestCaseProvider) isPropertyTest(method abi.Method) bool {
 	// Loop through all enabled prefixes to find a match
 	for _, prefix := range t.fuzzer.Config().Fuzzing.Testing.PropertyTesting.TestPrefixes {
 		if strings.HasPrefix(method.Name, prefix) {
-			if len(method.Inputs) == 0 && len(method.Outputs) == 1 && method.Outputs[0].Type.T == abi.BoolTy {
+			if len(method.Inputs) == 0 && len(method.Outputs) == 1 && method.Outputs[0].Type.T == abi.BoolTy && method.IsConstant() {
 				return true
 			}
 		}

--- a/fuzzing/testdata/contracts/deployments/deployment_with_args.sol
+++ b/fuzzing/testdata/contracts/deployments/deployment_with_args.sol
@@ -15,15 +15,15 @@ contract DeploymentWithArgs {
         z = _z;
     }
 
-    function fuzz_checkX() public returns (bool) {
+    function fuzz_checkX() public view returns (bool) {
         return x != 123456789;
     }
 
-    function fuzz_checkY() public returns (bool) {
+    function fuzz_checkY() public view returns (bool) {
         return y != 0x5465;
     }
 
-    function fuzz_checkZ() public returns (bool) {
+    function fuzz_checkZ() public view returns (bool) {
         return z.a != 0x4d2;
     }
 
@@ -40,7 +40,7 @@ contract Dependent {
         deployed = _deployed;
     }
 
-    function fuzz_checkDeployed() public returns (bool) {
+    function fuzz_checkDeployed() public view returns (bool) {
         return deployed == 0x0000000000000000000000000000000000000000;
     }
 


### PR DESCRIPTION
The `isPropertyTest` function identifies whether a given ABI method is a property test or not. However, this function failed to check whether the function was read-only. Thus, the following function would have been considered valid

```
function my_func() returns(bool) public {
  // I am changing state
 return true;
}
```

The fix is to simply add a `method.IsConstant` check.

Note that this PR also fixes up a few comments.