### PR TITLE
add library support for crytic-compile platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,8 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip3 install --no-cache-dir solc-select crytic-compile
+          pip3 install --no-cache-dir solc-select 
+          pip3 install --no-cache-dir git+https://github.com/crytic/crytic-compile.git@feat/add-libraries-to-solc-export#egg=crytic-compile
 
       - name: Install solc
         run: |

--- a/fuzzing/contracts/contract.go
+++ b/fuzzing/contracts/contract.go
@@ -4,17 +4,17 @@ import (
 	"github.com/crytic/medusa/compilation/types"
 )
 
-// Contracts describes an array of contracts
-type Contracts []*Contract
+// Contracts describes a mapping of contracts by name
+type Contracts map[string]*Contract
 
 // MatchBytecode takes init and/or runtime bytecode and attempts to match it to a contract definition in the
 // current list of contracts. It returns the contract definition if found. Otherwise, it returns nil.
 func (c Contracts) MatchBytecode(initBytecode []byte, runtimeBytecode []byte) *Contract {
 	// Loop through all our contract definitions to find a match.
-	for i := 0; i < len(c); i++ {
+	for _, contract := range c {
 		// If we have a match, register the deployed contract.
-		if c[i].CompiledContract().IsMatch(initBytecode, runtimeBytecode) {
-			return c[i]
+		if contract.CompiledContract().IsMatch(initBytecode, runtimeBytecode) {
+			return contract
 		}
 	}
 

--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -694,3 +694,22 @@ func TestDeploymentOrderWithCoverage(t *testing.T) {
 		},
 	})
 }
+
+// TestDeploymentsExternalLibrary runs a test to ensure external libraries behave correctly.
+func TestDeploymentsExternalLibrary(t *testing.T) {
+	runFuzzerTest(t, &fuzzerSolcFileTest{
+		filePath: "testdata/contracts/deployments/external_library.sol",
+		configUpdates: func(config *config.ProjectConfig) {
+			config.Fuzzing.DeploymentOrder = []string{"TestExternalLibrary"}
+			config.Fuzzing.TestLimit = 100 // this test should expose a failure quickly.
+		},
+		method: func(f *fuzzerTestContext) {
+			// Start the fuzzer
+			err := f.fuzzer.Start()
+			assert.NoError(t, err)
+			// Check for any failed tests and verify coverage was captured
+			assertFailedTestsExpected(f, true)
+			assertCorpusCallSequencesCollected(f, true)
+		},
+	})
+}

--- a/fuzzing/testdata/contracts/deployments/external_library.sol
+++ b/fuzzing/testdata/contracts/deployments/external_library.sol
@@ -1,0 +1,27 @@
+library Library1 {
+    function getLibrary() public returns(string memory) {
+        return "Library";
+    }
+}
+library Library2 {
+    function getLibrary() public returns(string memory) {
+        Library1.getLibrary();
+    }
+}
+library Library3 {
+    function getLibrary() public returns(string memory) {
+        Library2.getLibrary();
+        Library1.getLibrary();
+    }
+}
+contract TestExternalLibrary {
+    function test() public {
+        Library3.getLibrary();
+
+    }
+    function fuzz_me() public returns(bool){
+        if (keccak256(abi.encodePacked(Library3.getLibrary())) == keccak256(abi.encodePacked("Library"))) {
+            return false;            
+        }
+    }
+}


### PR DESCRIPTION
The solc export format now has the dependencies resolved in https://github.com/crytic/crytic-compile/pull/480 so it's possible to just deploy the necessary libraries in order for each contract. For recursive dependencies i.e. a library depends on a library, the previously deployed libraries are looked through for matching placeholders.

- [ ] Address TODO by refactoring duplicate deployment code
- [ ] Decide whether solc/truffle compilation needs to be updated or dropped
- [ ] See if this works for Foundry/ Hardhat