### PR TITLE
Fix nil dereference when calling `SetTarget`

### DIFF
--- a/compilation/compilation_config.go
+++ b/compilation/compilation_config.go
@@ -52,11 +52,6 @@ func NewCompilationConfigFromPlatformConfig(platformConfig platforms.PlatformCon
 // is then used to compile the underlying targets. Returns a list of compilations returned by the platform provider or
 // an error. Command-line input may also be returned in either case.,
 func (c *CompilationConfig) Compile() ([]types.Compilation, string, error) {
-	// Verify the platform is valid
-	if !IsSupportedCompilationPlatform(c.Platform) {
-		return nil, "", fmt.Errorf("could not compile from configs: platform '%s' is unsupported", c.Platform)
-	}
-
 	// Get the platform config
 	platformConfig, err := c.GetPlatformConfig()
 	if err != nil {
@@ -69,6 +64,16 @@ func (c *CompilationConfig) Compile() ([]types.Compilation, string, error) {
 
 // GetPlatformConfig will return the de-serialized version of platforms.PlatformConfig for a given CompilationConfig
 func (c *CompilationConfig) GetPlatformConfig() (platforms.PlatformConfig, error) {
+	// Ensure that the platform is non-empty
+	if c.Platform == "" {
+		return nil, fmt.Errorf("must specify a platform for compilation")
+	}
+
+	// Ensure that the platform is supported
+	if !IsSupportedCompilationPlatform(c.Platform) {
+		return nil, fmt.Errorf("compilation platform '%v' is unsupported", c.Platform)
+	}
+
 	// Allocate a platform config given our platform string in our compilation config
 	// It is necessary to do so as json.Unmarshal needs a concrete structure to populate
 	platformConfig := GetDefaultPlatformConfig(c.Platform)

--- a/compilation/compilation_config.go
+++ b/compilation/compilation_config.go
@@ -92,7 +92,10 @@ func (c *CompilationConfig) SetPlatformConfig(platformConfig platforms.PlatformC
 		return errors.New("platformConfig must be non-nil")
 	}
 
-	// Update platform
+	// Update platform, assuming the platform is supported
+	if !IsSupportedCompilationPlatform(platformConfig.Platform()) {
+		return fmt.Errorf("compilation platform '%v' is unsupported", platformConfig.Platform)
+	}
 	c.Platform = platformConfig.Platform()
 
 	// Serialize

--- a/compilation/compilation_config.go
+++ b/compilation/compilation_config.go
@@ -94,7 +94,7 @@ func (c *CompilationConfig) SetPlatformConfig(platformConfig platforms.PlatformC
 
 	// Update platform, assuming the platform is supported
 	if !IsSupportedCompilationPlatform(platformConfig.Platform()) {
-		return fmt.Errorf("compilation platform '%v' is unsupported", platformConfig.Platform)
+		return fmt.Errorf("compilation platform '%v' is unsupported", platformConfig.Platform())
 	}
 	c.Platform = platformConfig.Platform()
 


### PR DESCRIPTION
If in the `medusa.json` file, a `compilation.platform` is set that is not supported WHILE `--target` is set using the CLI flag, then the `SetTarget` function is called. The `SetTarget` function would then try to access the `platforms.PlatformConfig` for an un-supported platform which would cause a panic. Here is an example panic stack trace:
```
➜  secureum-medusa git:(main) ✗ medusa fuzz --target contracts/SignedWadMathTest.sol --deployment-order SignedWadMathTest
⇾ Reading the configuration file at: /Users/anishnaik/Documents/secureum-medusa/medusa.json
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1014588f8]

goroutine 1 [running]:
github.com/crytic/medusa/compilation.GetDefaultPlatformConfig(...)
        /Users/anishnaik/Documents/medusa/compilation/supported_platforms.go:66
github.com/crytic/medusa/compilation.(*CompilationConfig).GetPlatformConfig(0x1400012b7d0)
        /Users/anishnaik/Documents/medusa/compilation/compilation_config.go:74 +0x58
github.com/crytic/medusa/compilation.(*CompilationConfig).SetTarget(0x1400014c700?, {0x16f073315, 0x1f})
        /Users/anishnaik/Documents/medusa/compilation/compilation_config.go:109 +0x28
github.com/crytic/medusa/cmd.updateProjectConfigWithFuzzFlags(0x140002b6880?, 0x14000275b80)
        /Users/anishnaik/Documents/medusa/cmd/fuzz_flags.go:86 +0x6c
github.com/crytic/medusa/cmd.cmdRunFuzz(0x101d74e40?, {0x14000296ac0?, 0x4?, 0x4?})
        /Users/anishnaik/Documents/medusa/cmd/fuzz.go:130 +0x47c
github.com/spf13/cobra.(*Command).execute(0x101d74e40, {0x14000296a80, 0x4, 0x4})
        /Users/anishnaik/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x5c8
github.com/spf13/cobra.(*Command).ExecuteC(0x101d74880)
        /Users/anishnaik/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/anishnaik/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/crytic/medusa/cmd.Execute(...)
        /Users/anishnaik/Documents/medusa/cmd/root.go:27
main.main()
        /Users/anishnaik/Documents/medusa/main.go:10 +0x38
```

To trigger the bug yourself, update the `compilation.platform` in the `medusa.json` file in this [repo](https://github.com/crytic/secureum-medusa) to something like "potato" and then run
`medusa fuzz --target contracts/SignedWadMathTest.sol --deployment-order SignedWadMathTest`

This PR aims to fix this by adding two checks to the `GetPlatformConfig` function. Changes were made to this function since `SetTarget` and `Compile` all rely on this function to retrieve the platform configuration for a given platform. Thus, this function now makes sure that `PlatformConfig.Target` is non-empty and is supported. Additionally, another check is added to `SetPlatformConfig` to make sure that the `platformConfig.Platform()` is supported.