### PR TITLE
Lower log level for "Corpus item is disabled"

### DIFF
--- a/fuzzing/corpus/corpus.go
+++ b/fuzzing/corpus/corpus.go
@@ -222,7 +222,7 @@ func (c *Corpus) initializeSequences(sequenceFiles *corpusDirectory[calls.CallSe
 			}
 			c.unexecutedCallSequences = append(c.unexecutedCallSequences, sequence)
 		} else {
-			c.logger.Warn("Corpus item ", colors.Bold, sequenceFileData.fileName, colors.Reset, " disabled due to error when replaying it", sequenceInvalidError)
+			c.logger.Debug("Corpus item ", colors.Bold, sequenceFileData.fileName, colors.Reset, " disabled due to error when replaying it", sequenceInvalidError)
 		}
 
 		// Revert chain state to our starting point to test the next sequence.


### PR DESCRIPTION
Based on user feedback this warning can become quite annoying when the corpus gets large. For example, if you have 60 corpus items that are invalid, there will 60 CLI messages highlighting that none of them are usable. This is a degradation of UX.

This PR lowers the log level of this log from `warn` to `debug`