### PR TITLE
Added denomination parsing to AST value extraction

### DIFF
--- a/fuzzing/testdata/contracts/value_generation/ast_value_extraction.sol
+++ b/fuzzing/testdata/contracts/value_generation/ast_value_extraction.sol
@@ -1,0 +1,48 @@
+// This contract verifies the fuzzer can extract AST literals of different subdenominations from the file.
+contract TestContract {
+    function addressValues() public {
+        address x = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+        assert(x != address(0x1234567890123456789012345678901234567890));
+   }
+    function uintValues() public {
+        // Use all integer denoms
+        uint x = 111;
+        x = 1 wei;
+        x = 2 gwei;
+        //x = 3 szabo;
+        //x = 4 finney;
+        x = 5 ether;
+        x = 6 seconds;
+        x = 7 minutes;
+        x = 8 hours;
+        x = 9 days;
+        x = 10 weeks;
+        //x = 11 years;
+
+        // Dummy assertion that should always pass.
+        assert(x != 0);
+   }
+   function intValues() public {
+           // Use all integer denoms
+           int x = -111;
+           x = -1 wei;
+           x = -2 gwei;
+           //x = -3 szabo;
+           //x = -4 finney;
+           x = -5 ether;
+           x = -6 seconds;
+           x = -7 minutes;
+           x = -8 hours;
+           x = -9 days;
+           x = -10 weeks;
+           //x = -11 years;
+
+           // Dummy assertion that should always pass.
+           assert(x != 0);
+      }
+   function stringValues() public {
+        string memory s = "testString";
+        s = "testString2";
+        assert(true);
+   }
+}

--- a/fuzzing/valuegeneration/value_set.go
+++ b/fuzzing/valuegeneration/value_set.go
@@ -64,6 +64,12 @@ func (vs *ValueSet) AddAddress(a common.Address) {
 	vs.addresses[a] = nil
 }
 
+// ContainsAddress checks if an address is contained in the ValueSet.
+func (vs *ValueSet) ContainsAddress(a common.Address) bool {
+	_, contains := vs.addresses[a]
+	return contains
+}
+
 // RemoveAddress removes an address item from the ValueSet.
 func (vs *ValueSet) RemoveAddress(a common.Address) {
 	delete(vs.addresses, a)
@@ -85,6 +91,12 @@ func (vs *ValueSet) AddInteger(b *big.Int) {
 	vs.integers[b.String()] = b
 }
 
+// ContainsInteger checks if an integer is contained in the ValueSet.
+func (vs *ValueSet) ContainsInteger(b *big.Int) bool {
+	_, contains := vs.integers[b.String()]
+	return contains
+}
+
 // RemoveInteger removes an integer item from the ValueSet.
 func (vs *ValueSet) RemoveInteger(b *big.Int) {
 	delete(vs.integers, b.String())
@@ -104,6 +116,12 @@ func (vs *ValueSet) Strings() []string {
 // AddString adds a string item to the ValueSet.
 func (vs *ValueSet) AddString(s string) {
 	vs.strings[s] = nil
+}
+
+// ContainsString checks if a string is contained in the ValueSet.
+func (vs *ValueSet) ContainsString(s string) bool {
+	_, contains := vs.strings[s]
+	return contains
 }
 
 // RemoveString removes a string item from the ValueSet.
@@ -131,6 +149,18 @@ func (vs *ValueSet) AddBytes(b []byte) {
 
 	// Add our hash to our "set" (map)
 	vs.bytes[hashStr] = b
+}
+
+// ContainsBytes checks if a byte sequence is contained in the ValueSet.
+func (vs *ValueSet) ContainsBytes(b []byte) bool {
+	// Calculate hash and reset our hash provider
+	vs.hashProvider.Write(b)
+	hashStr := hex.EncodeToString(vs.hashProvider.Sum(nil))
+	vs.hashProvider.Reset()
+
+	// Check if the key exists in our lookup
+	_, contains := vs.bytes[hashStr]
+	return contains
 }
 
 // RemoveBytes removes a byte sequence item from the ValueSet.

--- a/fuzzing/valuegeneration/value_set_from_ast.go
+++ b/fuzzing/valuegeneration/value_set_from_ast.go
@@ -1,7 +1,6 @@
 package valuegeneration
 
 import (
-	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/shopspring/decimal"
 	"math/big"
@@ -41,9 +40,6 @@ func (vs *ValueSet) SeedFromAst(ast any) {
 				} else {
 					if decValue, err := decimal.NewFromString(literalValue); err == nil {
 						b := getAbsoluteValueFromDenominatedValue(decValue, literalSubdenomination)
-						if literalSubdenomination != nil {
-							print(fmt.Sprintf("Number: %v\nDenom: %v\nResult: %v", literalValue, *literalSubdenomination, b.String()))
-						}
 						vs.AddInteger(b)
 						vs.AddInteger(new(big.Int).Neg(b))
 						vs.AddAddress(common.BigToAddress(b))

--- a/fuzzing/valuegeneration/value_set_from_ast.go
+++ b/fuzzing/valuegeneration/value_set_from_ast.go
@@ -40,7 +40,7 @@ func (vs *ValueSet) SeedFromAst(ast any) {
 					}
 				} else {
 					if decValue, err := decimal.NewFromString(literalValue); err == nil {
-						b := getValueInDenomination(decValue, literalSubdenomination)
+						b := getAbsoluteValueFromDenominatedValue(decValue, literalSubdenomination)
 						if literalSubdenomination != nil {
 							print(fmt.Sprintf("Number: %v\nDenom: %v\nResult: %v", literalValue, *literalSubdenomination, b.String()))
 						}
@@ -56,11 +56,11 @@ func (vs *ValueSet) SeedFromAst(ast any) {
 	})
 }
 
-// getValueInDenomination converts a given decimal number in a provided denomination to a big.Int
+// getAbsoluteValueFromDenominatedValue converts a given decimal number in a provided denomination to a big.Int
 // that represents its actual calculated value.
 // Note: Decimals must be used as big.Float is prone to similar mantissa-related precision issues as float32/float64.
 // Returns the calculated value given the floating point number in a given denomination.
-func getValueInDenomination(number decimal.Decimal, denomination *string) *big.Int {
+func getAbsoluteValueFromDenominatedValue(number decimal.Decimal, denomination *string) *big.Int {
 	// If the denomination is nil, we do nothing
 	if denomination == nil {
 		return number.BigInt()
@@ -71,39 +71,27 @@ func getValueInDenomination(number decimal.Decimal, denomination *string) *big.I
 	switch *denomination {
 	case "wei":
 		multiplier = decimal.NewFromFloat32(1)
-		break
 	case "gwei":
 		multiplier = decimal.NewFromFloat32(1e9)
-		break
 	case "szabo":
 		multiplier = decimal.NewFromFloat32(1e12)
-		break
 	case "finney":
 		multiplier = decimal.NewFromFloat32(1e15)
-		break
 	case "ether":
 		multiplier = decimal.NewFromFloat32(1e18)
-		break
 	case "seconds":
 		multiplier = decimal.NewFromFloat32(1)
-		break
 	case "minutes":
 		multiplier = decimal.NewFromFloat32(60)
-		break
 	case "hours":
 		multiplier = decimal.NewFromFloat32(60 * 60)
-		break
 	case "days":
 		multiplier = decimal.NewFromFloat32(60 * 60 * 24)
-		break
 	case "weeks":
 		multiplier = decimal.NewFromFloat32(60 * 60 * 24 * 7)
-		break
 	case "years":
 		multiplier = decimal.NewFromFloat32(60 * 60 * 24 * 7 * 365)
-		break
 	default:
-		break
 	}
 
 	// Obtain the transformed number as an integer.

--- a/fuzzing/valuegeneration/value_set_from_ast.go
+++ b/fuzzing/valuegeneration/value_set_from_ast.go
@@ -88,6 +88,7 @@ func getAbsoluteValueFromDenominatedValue(number decimal.Decimal, denomination *
 	case "years":
 		multiplier = decimal.NewFromFloat32(60 * 60 * 24 * 7 * 365)
 	default:
+		multiplier = decimal.NewFromFloat32(1)
 	}
 
 	// Obtain the transformed number as an integer.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
+	github.com/shopspring/decimal v1.3.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtm
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=


### PR DESCRIPTION
This PR adds denomination parsing to AST value extraction. This means types such as `wei`, `gwei`, `ether`, `weeks`, `years` should now be supported. This PR closes #156 , which was not solveable because the denomination was not parsed, so the correct value was not extracted for the `ValueSet`.

Unrelated changes:
- Added memory usage to printed metrics. Memory usage and worker resets now only show if your log level is DEBUG or lower.