### PR TITLE
Migrate to mdbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy GH Pages
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: cargo install --git https://github.com/montyly/mdBook.git mdbook || true
+      - run: cd docs && mdbook build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./docs/book
+
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # Medusa binary
 medusa
+
+# Medusa docs
+docs/book

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,13 @@
+[book]
+authors = ["Trail of Bits"]
+language = "en"
+multilingual = false
+src = "src"
+title = "Medusa"
+description = "This repository, brought to you by Trail of Bits, contains the source files for the Medusa documentation."
+
+[output.html]
+git-repository-url = "https://github.com/crytic/medusa"
+edit-url-template = "https://github.com/crytic/medusa/edit/master/docs/{path}"
+no-section-label = true
+default-theme = "light"

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,0 +1,12 @@
+# Introduction
+
+`medusa` is a cross-platform go-ethereum-based smart contract fuzzer inspired by Echidna. It provides parallelized fuzz testing of smart contracts through CLI, or its Go API that allows custom user-extended testing methodology.
+
+## Table of Contents
+
+- [Project Configuration](./project-configuration.md): Learn how to set up `medusa` for your project as well as the vast number of configuration options that can be set up based on your project needs.
+- [Command Line Interface](./command-line-interface.md): Learn how to use `medusa`'s CLI.
+- [API Overview (WIP)](./api-overview.md): Learn about medusa's Go API that can be used to perform advanced testing methodologies and extend `medusa`'s capabilities.
+- [Testing with `medusa`](./writing-tests.md): Learn how to perform testing using property mode, assertion mode, and optimization mode. We will discuss what the benefits of each mode are and how to set `medusa` up for each one.
+- [Cheatcodes](./cheatcodes.md): Learn about the various cheatcodes that are supported by `medusa`. Using these cheatcodes will significantly improve the efficiency and code quality of your fuzz tests.
+- [FAQ](./faq.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,10 @@
+# Summary
+
+- [Introduction](./README.md)
+- [Project Configuration](./project-configuration.md)
+- [Example Project Configuration File](./example-config-file.md)
+- [Command Line Interface](./command-line-interface.md)
+- [API Overview (WIP)](./api-overview.md)
+- [Testing with `medusa`](./writing-tests.md)
+- [Cheatcodes](./cheatcodes.md)
+- [FAQ](./faq.md)

--- a/docs/src/api-overview.md
+++ b/docs/src/api-overview.md
@@ -1,0 +1,185 @@
+# API Overview (WIP)
+
+`medusa` offers a lower level API to hook into various parts of the fuzzer, its workers, and underlying chains. Although assertion and property testing are two built-in testing providers, they are implementing using events and hooks offered throughout the `Fuzzer`, `FuzzerWorker`(s), and underlying `TestChain`. These same hooks can be used by external developers wishing to implement their own customing testing methodology. In the sections below, we explore some of the relevant components throughout `medusa`, their events/hooks, an example of creating custom testing methodology with it.
+
+## Component overview
+
+A rudimentary description of the objects/providers and their roles are explained below.
+
+### Data types
+
+- `ProjectConfig`: This defines the configuration for the Fuzzer, including the targets to compile, deploy, and how to fuzz or test them.
+
+- `ValueSet`: This is an object that acts as a dictionary of values, used in mutation operations. It is populated at compilation time with some rudimentary static analysis.
+
+- `Contract`: Can be thought of as a "contract definition", it is a data type which stores the name of the contract, and a reference to the underlying `CompiledContract`, a definition derived from compilation, containing the bytecode, source maps, ABI, etc.
+
+- `CallSequence`: This represents a list of `CallSequenceElement`s, which define a transaction to send, the suggested block number and timestamp delay to use, and stores a reference to the block/transaction/results when it is executed (for later querying in tests). They are used to generate and execute transaction sequences in the fuzzer.
+
+- `CoverageMaps` define a list of `CoverageMap` objects, which record all instruction offsets executed for a given contract address and code hash.
+
+- `TestCase` defines the interface for a test that the `Fuzzer` will track. It simply defines a name, ID, status (not started, running, passed, failed) and message for the `Fuzzer`.
+
+### Providers
+
+- `ValueGenerator`: This is an object that provides methods to generate values of different kinds for transactions. Examples include the `RandomValueGenerator` and superceding `MutationalValueGenerator`. They are provided a `ValueSet` by their worker, which they may use in generation operations.
+
+- `TestChain`: This is a fake chain that operates on fake block structures created for the purpose of testing. Rather than operating on `types.Transaction` (which requires signing), it operates on `core.Message`s, which are derived from transactions and simply allow you to set the `sender` field. It is responsible for:
+
+  - Maintaining state of the chain (blocks, transactions in them, results/receipts)
+  - Providing methods to create blocks, add transactions to them, commit them to chain, revert to previous block numbers.
+  - Allowing spoofing of block number and timestamp (commiting block number 1, then 50, jumping 49 blocks ahead), while simulating the existence of intermediate blocks.
+  - Provides methods to add tracers such as `evm.Logger` (standard go-ethereum tracers) or extend them with an additional interface (`TestChainTracer`) to also store any captured traced information in the execution results. This allows you to trace EVM execution for certain conditions, store results, and query them at a later time for testing.
+
+- `Fuzzer`: This is the main provider for the fuzzing process. It takes a `ProjectConfig` and is responsible for:
+
+  - Housing data shared between the `FuzzerWorker`s such as contract definitions, a `ValueSet` derived from compilation to use in value generation, the reference to `Corpus`, the `CoverageMaps` representing all coverage achieved, as well as maintaining `TestCase`s registered to it and printing their results.
+  - Compiling the targets defined by the project config and setting up state.
+  - Provides methods to start/stop the fuzzing process, add additional compilation targets, access the initial value set prior to fuzzing start, access corpus, config, register new test cases and report them finished.
+  - Starts the fuzzing process by creating a "base" `TestChain`, deploys compiled contracts, replays all corpus sequences to measure existing coverage from previous fuzzing campaign, then spawns as many `FuzzerWorker`s as configured on their own goroutines ("threads") and passes them the "base" `TestChain` (which they clone) to begin the fuzzing operation.
+    - Respawns `FuzzerWorker`s when they hit a config-defined reset limit for the amount of transaction sequences they should process before destroying themselves and freeing memory.
+    - Maintains the context for when fuzzing should stop, which all workers track.
+
+- `FuzzerWorker`: This describes an object spawned by the `Fuzzer` with a given "base" `TestChain` with target contracts already deployed, ready to be fuzzed. It clones this chain, then is called upon to begin creating fuzz transactions. It is responsible for:
+  - Maintaining a reference to the parent `Fuzzer` for any shared information between it and other workers (`Corpus`, total `CoverageMaps`, contract definitions to match deployment's bytecode, etc)
+  - Maintaining its own `TestChain` to run fuzzed transaction sequences.
+  - Maintaining its own `ValueSet` which derives from the `Fuzzer`'s `ValueSet` (populated by compilation or user-provided values through API), as each `FuzzerWorker` may populate its `ValueSet` with different runtime values depending on their own chain state.
+  - Spawning a `ValueGenerator` which uses the `ValueSet`, to generate values used to construct fuzzed transaction sequences.
+  - Most importantly, it continuously:
+    - Generates `CallSequence`s (a series of transactions), plays them on its `TestChain`, records the results of in each `CallSequenceElement`, and calls abstract/hookable "test functions" to indicate they should perform post-tx tests (for which they can return requests for a shrunk test sequence).
+    - Updates the total `CoverageMaps` and `Corpus` with the current `CallSequence` if the most recent call increased coverage.
+    - Processes any shrink requests from the previous step (shrink requests can define arbitrary criteria for shrinking).
+  - Eventually, hits the config-defined reset limit for how many sequences it should process, and destroys itself to free all memory, expecting the `Fuzzer` to respawn another in its place.
+
+## Creating a project configuration
+
+`medusa` is config-driven. To begin a fuzzing campaign on an API level, you must first define a project configuration so the fuzzer knows what contracts to compile, deploy, and how it should operate.
+
+When using `medusa` over command-line, it operates a project config similarly (see [docs](https://github.com/trailofbits/medusa/wiki/Project-Configuration) or [example](https://github.com/trailofbits/medusa/wiki/Example-Project-Configuration-File)). Similarly, interfacing with a `Fuzzer` requires a `ProjectConfig` object. After importing `medusa` into your Go project, you can create one like this:
+
+```go
+// Initialize a default project config with using crytic-compile as a compilation platform, and set the target it should compile.
+projectConfig := config.GetDefaultProjectConfig("crytic-compile")
+err := projectConfig.Compilation.SetTarget("contract.sol")
+if err != nil {
+    return err
+}
+
+// You can edit any of the values as you please.
+projectConfig.Fuzzing.Workers = 20
+projectConfig.Fuzzing.DeploymentOrder = []string{"TestContract1", "TestContract2"}
+```
+
+You may also instantiate the whole config in-line with all the fields you'd like, setting the underlying platform config yourself.
+
+> **NOTE**: The `CompilationConfig` and `PlatformConfig` WILL BE deprecated and replaced with something more intuitive in the future, as the `compilation` package has not been updated since the project's inception, prior to the release of generics in go 1.18.
+
+## Creating and starting the fuzzer
+
+After you have created a `ProjectConfig`, you can create a new `Fuzzer` with it, and tell it to start:
+
+```go
+	// Create our fuzzer
+	fuzzer, err := fuzzing.NewFuzzer(*projectConfig)
+	if err != nil {
+		return err
+	}
+
+	// Start the fuzzer
+	err = fuzzer.Start()
+	if err != nil {
+		return err
+	}
+
+    // Fetch test cases results
+    testCases := fuzzer.TestCases()
+[...]
+```
+
+> **Note**: `Fuzzer.Start()` is a blocking operation. If you wish to stop, you must define a TestLimit or Timeout in your config. Otherwise start it on another goroutine and call `Fuzzer.Stop()` to stop it.
+
+## Events/Hooks
+
+### Events
+
+Now it may be the case that you wish to hook the `Fuzzer`, `FuzzerWorker`, or `TestChain` to provide your own functionality. You can add your own testing methodology, and even power it with your own low-level EVM execution tracers to store and query results about each call.
+
+There are a few events/hooks that may be useful of the bat:
+
+The `Fuzzer` maintains event emitters for the following events under `Fuzzer.Events.*`:
+
+- `FuzzerStartingEvent`: Indicates a `Fuzzer` is starting and provides a reference to it.
+
+- `FuzzerStoppingEvent`: Indicates a `Fuzzer` has just stopped all workers and is about to print results and exit.
+
+- `FuzzerWorkerCreatedEvent`: Indicates a `FuzzerWorker` was created by a `Fuzzer`. It provides a reference to the `FuzzerWorker` spawned. The parent `Fuzzer` can be accessed through `FuzzerWorker.Fuzzer()`.
+- `FuzzerWorkerDestroyedEvent`: Indicates a `FuzzerWorker` was destroyed. This can happen either due to hitting the config-defined worker reset limit or the fuzzing operation stopping. It provides a reference to the destroyed worker (for reference, though this should not be stored, to allow memory to free).
+
+The `FuzzerWorker` maintains event emiters for the following events under `FuzzerWorker.Events.*`:
+
+- `FuzzerWorkerChainCreatedEvent`: This indicates the `FuzzerWorker` is about to begin working and has created its chain (but not yet copied data from the "base" `TestChain` the `Fuzzer` provided). This offers an opportunity to attach tracers for calls made during chain setup. It provides a reference to the `FuzzerWorker` and its underlying `TestChain`.
+
+- `FuzzerWorkerChainSetupEvent`: This indicates the `FuzzerWorker` is about to begin working and has both created its chain, and copied data from the "base" `TestChain`, so the initial deployment of contracts is complete and fuzzing is ready to begin. It provides a reference to the `FuzzerWorker` and its underlying `TestChain`.
+
+- `CallSequenceTesting`: This indicates a new `CallSequence` is about to be generated and tested by the `FuzzerWorker`. It provides a reference to the `FuzzerWorker`.
+
+- `CallSequenceTested`: This indicates a `CallSequence` was just tested by the `FuzzerWorker`. It provides a reference to the `FuzzerWorker`.
+
+- `FuzzerWorkerContractAddedEvent`: This indicates a contract was added on the `FuzzerWorker`'s underlying `TestChain`. This event is emitted when the contract byte code is resolved to a `Contract` definition known by the `Fuzzer`. It may be emitted due to a contract deployment, or the reverting of a block which caused a SELFDESTRUCT. It provides a reference to the `FuzzerWorker`, the deployed contract address, and the `Contract` definition that it was matched to.
+
+- `FuzzerWorkerContractDeletedEvent`: This indicates a contract was removed on the `FuzzerWorker`'s underlying `TestChain`. It may be emitted due to a contract deployment which was reverted, or a SELFDESTRUCT operation. It provides a reference to the `FuzzerWorker`, the deployed contract address, and the `Contract` definition that it was matched to.
+
+The `TestChain` maintains event emitters for the following events under `TestChain.Events.*`:
+
+- `PendingBlockCreatedEvent`: This indicates a new block is being created but has not yet been committed to the chain. The block is empty at this point but will likely be populated. It provides a reference to the `Block` and `TestChain`.
+
+- `PendingBlockAddedTxEvent`: This indicates a pending block which has not yet been commited to chain has added a transaction to it, as it is being constructed. It provides a reference to the `Block`, `TestChain`, and index of the transaction in the `Block`.
+
+- `PendingBlockCommittedEvent`: This indicates a pending block was committed to chain as the new head. It provides a reference to the `Block` and `TestChain`.
+
+- `PendingBlockDiscardedEvent`: This indicates a pending block was not committed to chain and was instead discarded.
+
+- `BlocksRemovedEvent`: This indicates blocks were removed from the chain. This happens when a chain revert to a previous block number is invoked. It provides a reference to the `Block` and `TestChain`.
+
+- `ContractDeploymentsAddedEvent`: This indicates a new contract deployment was detected on chain. It provides a reference to the `TestChain`, as well as information captured about the bytecode. This may be triggered on contract deployment, or the reverting of a SELFDESTRUCT operation.
+
+- `ContractDeploymentsRemovedEvent`: This indicates a previously deployed contract deployment was removed from chain. It provides a reference to the `TestChain`, as well as information captured about the bytecode. This may be triggered on revert of a contract deployment, or a SELFDESTRUCT operation.
+
+### Hooks
+
+The `Fuzzer` maintains hooks for some of its functionality under `Fuzzer.Hooks.*`:
+
+- `NewValueGeneratorFunc`: This method is used to create a `ValueGenerator` for each `FuzzerWorker`. By default, this uses a `MutationalValueGenerator` constructed with the provided `ValueSet`. It can be replaced to provide a custom `ValueGenerator`.
+
+- `TestChainSetupFunc`: This method is used to set up a chain's initial state before fuzzing. By default, this method deploys all contracts compiled and marked for deployment in the `ProjectConfig` provided to the `Fuzzer`. It only deploys contracts if they have no constructor arguments. This can be replaced with your own method to do custom deployments.
+
+  - **Note**: We do not recommend replacing this for now, as the `Contract` definitions may not be known to the `Fuzzer`. Additionally, `SenderAddresses` and `DeployerAddress` are the only addresses funded at genesis. This will be updated at a later time.
+
+- `CallSequenceTestFuncs`: This is a list of functions which are called after each `FuzzerWorker` executed another call in its current `CallSequence`. It takes the `FuzzerWorker` and `CallSequence` as input, and is expected to return a list of `ShinkRequest`s if some interesting result was found and we wish for the `FuzzerWorker` to shrink the sequence. You can add a function here as part of custom post-call testing methodology to check if some property was violated, then request a shrunken sequence for it with arbitrary criteria to verify the shrunk sequence satisfies your requirements (e.g. violating the same property again).
+
+### Extending testing methodology
+
+Although we will build out guidance on how you can solve different challenges or employ different tests with this lower level API, we intend to wrap some of this into a higher level API that allows testing complex post-call/event conditions with just a few lines of code externally. The lower level API will serve for more granular control across the system, and fine tuned optimizations.
+
+To ensure testing methodology was agnostic and extensible in `medusa`, we note that both assertion and property testing is implemented through the abovementioned events and hooks. When a higher level API is introduced, we intend to migrate these test case providers to that API.
+
+For now, the built-in `AssertionTestCaseProvider` (found [here](https://github.com/trailofbits/medusa/blob/8036697794481b7bf9fa78c922ec7fa6a8a3005c/fuzzing/test_case_assertion_provider.go)) and its test cases (found [here](https://github.com/trailofbits/medusa/blob/8036697794481b7bf9fa78c922ec7fa6a8a3005c/fuzzing/test_case_assertion.go)) are an example of code that _could_ exist externally outside of `medusa`, but plug into it to offer extended testing methodology. Although it makes use of some private variables, they can be replaced with public getter functions that are available. As such, if assertion testing didn't exist in `medusa` natively, you could've implemented it yourself externally!
+
+In the end, using it would look something like this:
+
+```go
+	// Create our fuzzer
+	fuzzer, err := fuzzing.NewFuzzer(*projectConfig)
+	if err != nil {
+		return err
+	}
+
+	// Attach our custom test case provider
+	attachAssertionTestCaseProvider(fuzzer)
+
+	// Start the fuzzer
+	err = fuzzer.Start()
+	if err != nil {
+		return err
+	}
+```

--- a/docs/src/cheatcodes.md
+++ b/docs/src/cheatcodes.md
@@ -1,0 +1,3 @@
+# Cheatcodes
+
+TODO

--- a/docs/src/command-line-interface.md
+++ b/docs/src/command-line-interface.md
@@ -1,0 +1,75 @@
+# Command Line Interface
+
+`medusa` can run parallelized fuzz testing of smart contracts through its Command Line Interface (CLI). The CLI supports three main commands and each command has a variety of flags:
+
+1. `medusa init [platform]` will initialize `medusa`'s project configuration file
+2. `medusa fuzz` will begin the fuzzing campaign.
+3. `medusa completion <shell>` will provide an autocompletion script for a given shell
+
+Let's look at each command.
+
+> **Note**: We highly recommend reading more about `medusa`'s [project configuration](./Project-Configuration.md) parameters before diving into `medusa`'s CLI capabilities.
+
+## Initializing a project configuration
+
+To create a `medusa` project configuration, invoke `medusa init [platform]` to create a [configuration file](./Example-Project-Configuration-File.md) for the provided platform within your current working directory. Invoking this command without a `platform` argument will result in `medusa` using `crytic-compile` as the default compilation platform.
+
+> Note that the output of `medusa init`, which is equivalent to `medusa init crytic-compile`, is considered the **default configuration** of `medusa`
+
+While running `medusa init`, you have access to two flags:
+
+1. `medusa init [platform] --out myConfig.json`: The `--out` value will determine the output path where your project configuration file will be outputted. Without `--out`, the default output path is `medusa.json` in the current working directory.
+2. `medusa init [platform] --target myContract.sol`: The `--target` value will determine the compilation target.
+
+## Running a fuzzing campaign
+
+After you have a project configuration setup, you can now run a fuzzing campaign.
+
+To run a fuzzing campaign, invoke `medusa fuzz`. The `fuzz` command supports a variety of flags:
+
+- `medusa fuzz --config myConfig.json`: Will use the configuration in `myConfig.json` as the project configuration. If `--config` is not set, `medusa` will look for a `medusa.json` file in the current working directory
+- `medusa fuzz --target myContract.sol`: Will set the compilation target to `myContract.sol`
+- `medusa fuzz --workers 20`: Will set the number of `workers` to 20 threads
+- `medusa fuzz --timeout 1000`: Will set the `timeout` to 1000 seconds
+- `medusa fuzz --test-limit 50000`: Will set the `testLimit` to 50000 function calls
+- `medusa fuzz --seq-len 50`: Will set the `callSequenceLength` to 50 transactions
+- `medusa fuzz --deployment-order "FirstContract,SecondContract"`: Will set the deployment order to `[FirstContract, SecondContract]`
+- `medusa fuzz --corpus-dir myCorpus`: Will set the corpus directory _path_ to `myCorpus`
+- `medusa fuzz --senders "0x10000,0x20000,0x30000"`: Will set the `senderAdddresses` to `[0x10000, 0x20000, 0x30000]`
+- `medusa fuzz --deployer "0x10000"`: Will set the `deployerAddress` to `0x10000`
+- `medusa fuzz --assertion-mode`: Will set `assertionTesting.enabled` to `true`
+- `medusa fuzz --optimization-mode`: Will set `optimizationTesting.enabled` to `true`
+- `medusa fuzz --trace-all`: Will set `traceAll` to `true`
+
+Note that the `fuzz` command will use both the project configuration file in addition to any flags to determine the _final_ project configuration. Thus, it uses both of them in tandem.
+
+This results in four different ways to run `medusa`:
+
+1. `medusa fuzz`: Run `medusa` using the configuration in `medusa.json` with no CLI updates.
+   > 🚩 If `medusa.json` is not found, we will use the **default configuration**.
+2. `medusa fuzz --workers 20 --test-limit 50000`: Run `medusa` using the configuration in `medusa.json` and override the `workers` and `testLimit` parameters.
+   > 🚩 If `medusa.json` is not found, we will use the **default configuration** and override the `workers` and `testLimit` parameters.
+3. `medusa fuzz --config myConfig.json`: Run `medusa` using the configuration in `myConfig.json` with no CLI updates.
+   > 🚩 If `myConfig.json` is not found, `medusa` will throw an error
+4. `medusa fuzz --config myConfig.json --workers 20 --test-limit 50000`: Run `medusa` using the configuration in `myConfig.json` and override the `workers` and `testLimit` parameters.
+   > 🚩 If `myConfig.json` is not found, `medusa` will throw an error
+
+## Autocompletion
+
+`medusa` also provides the ability to generate autocompletion scripts for a given shell. Once the autocompletion script is ran for a given shell, `medusa`'s commands and flags can now be tab-autocompleted. The following shells are supported:
+
+1. bash
+2. zsh
+3. Powershell
+
+To understand how to run the autocompletion script for a given shell, run the following command
+
+```bash
+medusa completion --help
+```
+
+Once you know how to run the autocompletion script, retrieve the script for that given shell using the following command.
+
+```bash
+medusa completion <shell>
+```

--- a/docs/src/example-config-file.md
+++ b/docs/src/example-config-file.md
@@ -1,0 +1,46 @@
+# Example Project Configuration File
+
+```json
+{
+  "fuzzing": {
+    "workers": 10,
+    "workerResetLimit": 50,
+    "timeout": 0,
+    "testLimit": 0,
+    "callSequenceLength": 100,
+    "corpusDirectory": "",
+    "coverageEnabled": true,
+    "deploymentOrder": [],
+    "deployerAddress": "0x1111111111111111111111111111111111111111",
+    "senderAddresses": [
+      "0x1111111111111111111111111111111111111111",
+      "0x2222222222222222222222222222222222222222",
+      "0x3333333333333333333333333333333333333333"
+    ],
+    "blockNumberDelayMax": 60480,
+    "blockTimestampDelayMax": 604800,
+    "blockGasLimit": 125000000,
+    "transactionGasLimit": 12500000,
+    "testing": {
+      "stopOnFailedTest": true,
+      "assertionTesting": {
+        "enabled": false,
+        "testViewMethods": false
+      },
+      "propertyTesting": {
+        "enabled": true,
+        "testPrefixes": ["fuzz_"]
+      }
+    }
+  },
+  "compilation": {
+    "platform": "crytic-compile",
+    "platformConfig": {
+      "target": ".",
+      "solcVersion": "",
+      "exportDirectory": "",
+      "args": []
+    }
+  }
+}
+```

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -1,0 +1,16 @@
+# Frequently Asked Questions
+
+**Why create a new fuzzer if Echidna is already a great fuzzer?**
+
+With medusa, we are exploring a different EVM implementation and language for our smart contract fuzzer. While Echidna is already doing an amazing job, medusa offers the following advantages:
+
+- It is written in Go, easing the maintenance and allowing the creation of a native API for future integration into other projects.
+- It uses geth as a base, ensuring the EVM equivalence.
+
+**Should I switch to medusa right away?**
+
+We do not recommend switching to medusa until it is extensively tested. However we encourage you to try it, and [let us know your experience](https://github.com/trailofbits/medusa/issues). In that sense, Echidna is our robust and well tested fuzzer, while medusa is our new exploratory fuzzer. [Follow us](https://twitter.com/trailofbits/) to hear updates about medusa as it grows in maturity.
+
+**Will all the previous available documentation from [secure-contracts.com](https://secure-contracts.com/) will apply to medusa?**
+
+In general, yes. All the information on testing approaches and techniques will apply for medusa. There are, however, different configuration options names and a few missing or different features in medusa from Echidna that we will be updating over time.

--- a/docs/src/project-configuration.md
+++ b/docs/src/project-configuration.md
@@ -1,0 +1,232 @@
+# Project Configuration
+
+The project configuration will dictate the compilation, fuzzing, and logging parameters for `medusa`. The fuzzing parameters are determined by the **fuzzing configuration**, the compilation parameters are determined by the **compilation configuration**, and the logging parameters are determined by the **logging configuration**. Thus, a _project_ configuration is a combination of all three configurations.
+
+Run `medusa init` using [`medusa`'s CLI](https://github.com/crytic/medusa/wiki/Command-Line-Interface) to generate a `medusa.json` with the default value for each configuration. See [Example Project Configuration File](https://github.com/crytic/medusa/wiki/Example-Project-Configuration-File) for an example `medusa.json`.
+
+Now, we will walk through each configuration (fuzzing, compilation, and logging) and review the various options for each one.
+
+## Fuzzing Configuration
+
+The fuzzing configuration defines the parameters for the fuzzing campaign:
+
+- `workers`
+  - **Type**: Integer
+  - **Description**: The number of worker threads to parallelize fuzzing operations on.
+  - **Default**: 10
+- `workerResetLimit`
+  - **Type**: Integer
+  - **Description**: The number of call sequences a worker should process on its underlying chain before being fully reset, freeing memory. After resetting, the worker will be re-created and continue processing of call sequences.
+    > 🚩 This setting, along with `workers` influence the speed and memory consumption of the fuzzer. Setting this value higher will result in greater memory consumption per worker. Setting it too high will result in the in-memory chain's database growing to a size that is slower to process. Setting it too low may result in frequent worker resets that are computationally expensive for complex contract deployments that need to be replayed during worker reconstruction.
+  - **Default**: 50
+- `timeout`
+  - **Type**: Integer
+  - **Description**: The number of seconds before the fuzzing campaign should be terminated. If a zero value is provided, the timeout will not be enforced. The timeout begins counting after compilation succeeds and the fuzzing campaign has started.
+  - **Default**: 0
+- `testLimit`
+  - **Type**: Unsigned Integer
+  - **Description**: The number of function calls to make before the fuzzing campaign should be terminated. If a zero value is provided, no call limit will be enforced.
+  - **Default**: 0
+- `callSequenceLength`
+  - **Type**: Integer
+  - **Description**: The maximum number of function calls to generate in a single call sequence in the attempt to violate properties. After every `callSequenceLength` function calls, the blockchain is reset for the next sequence of transactions.
+  - **Default**: 100
+- `coverageEnabled`
+  - **Type**: Boolean
+  - **Description**: Whether coverage-increasing call sequences should be saved in the corpus for the fuzzer to mutate / re-use. This aims to help achieve greater coverage across contracts when testing.
+  - **Default**: `true`
+- `corpusDirectory`
+  - **Type**: String
+  - **Description**: The file path where the corpus should be saved. The corpus collects artifacts during a fuzzing campaign that help drive fuzzer features (e.g. a call sequence that increases code coverage is stored in the corpus). This sequence can then be re-used / mutated by the fuzzer during the next fuzzing campaign.
+  - **Default**: ""
+- `deploymentOrder`
+  - **Type**: [String] (e.g. `["FirstContract", "SecondContract", "ThirdContract"]`)
+  - **Description**: A list of contract names that indicates the order in which the compiled contracts (contracts resulting from compilation) should be deployed to the fuzzer on startup. **If there is more than one contract in the target system, at least one contract name must be specified here.**
+    > 🚩 Changing this order may render entries in the corpus invalid. It is recommended to clear your corpus when doing so.
+  - **Default**: []
+- `constructorArgs`
+  - **Type**: Mapping of contract to a mapping of variable name to value (contract => variable => value)
+  - **Description**: If a contract in the `deploymentOrder` has a constructor that takes in variables, these can be specified here. An example can be found [here](TODO).
+  - **Default**: Empty mapping
+- `deployerAddress`
+  - **Type**: Address
+  - **Description**: The address used to deploy contracts on startup, represented as a hex string.
+    > 🚩 Changing this address may render entries in the corpus invalid. It is recommended to clear your corpus when doing so.
+  - **Default**: `0x30000`
+- `senderAddresses`
+  - **Type**: [Address]
+  - **Description**: Defines the account addresses used to send function calls to deployed contracts in the fuzzing campaign.
+    > 🚩 Changing these addresses may render entries in the corpus invalid. It is recommended to clear your corpus when doing so.
+  - **Default**: `[0x10000, 0x20000, 0x30000]`
+- `blockNumberDelayMax`
+  - **Type**: Unsigned Integer
+  - **Description**: Defines the maximum block number jump the fuzzer should make between test transactions. The fuzzer will use this value to make the next block's block number between `[1, blockNumberDelayMax]` more than that of the previous block. Jumping block numbers allows `medusa` to enter code paths that require a given number of blocks to pass.
+  - **Default**: 60_480
+- `blockTimestampDelayMax`
+  - **Type**: Unsigned Integer
+  - **Description**: The number of the maximum block timestamp jump the fuzzer should make between test transactions. The fuzzer will use this value to make the next block's timestamp between `[1, blockTimestampDelayMax]` more than that of the previous block. Jumping time allows `medusa` to enter code paths that require a given amount of time to pass.
+  - **Default**: 604_800
+- `blockGasLimit`
+  - **Type**: Unsigned Integer
+  - **Description**: The number of the maximum amount of gas a block's transactions can use in total (thus defining max transactions per block).
+    > 🚩 It is advised not to change this naively, as a minimum must be set for the chain to operate.
+  - **Default**: 125_000_000
+- `transactionGasLimit`
+  - **Type**: Unsigned Integer
+  - **Description**: Defines the amount of gas sent with each fuzzer-generated transaction.
+    > 🚩 It is advised not to change this naively, as a minimum must be set for the chain to operate.
+  - **Default**: 12_500_000
+- `testing`
+  - **Type**: Struct
+  - **Description**: This struct will define the configuration for the various testing modes that are supported by `medusa`
+  - **Components**:
+    - `stopOnFailedTest`
+      - **Type**: Boolean
+      - **Description**: Determines whether the fuzzer should stop execution after the first _failed_ test.
+      - **Default**: `true`
+    - `stopOnFailedContractMatching`
+      - **Type**: Boolean
+      - **Description**: Determines whether the fuzzer should stop execution if it is unable to match the bytecode of a dynamically deployed contract. A dynamically deployed contract is one that is created during the fuzzing campaign (versus one that is specified in the `deploymentOrder`).
+      - **Default**: `true`
+    - `stopOnNoTests`
+      - **Type**: Boolean
+      - **Description**: Determines whether the fuzzer should stop execution if no tests are found (property tests, assertion tests, optimization tests, or custom API-level tests)
+      - **Default**: `true`
+    - `testAllContracts`
+      - **Type**: Boolean
+      - **Description**: Determines whether all contracts should be tested (including dynamically deployed ones), rather than just the contracts specified in the project configuration's `deploymentOrder`.
+      - **Default**: `false`
+    - `traceAll`:
+      - **Type**: Boolean
+      - **Description**: Determines whether an "execution trace" should be attached to each element of a call sequence that triggered a test failure. An execution trace showcases the various contract calls, return data, and emitted events that a call encountered. By default, a trace is attached for the _final_ call in the call sequence that triggered a test failure.
+      - **Default**: `false`
+    - `assertionTesting`
+      - **Type**: Struct
+      - **Description**: This struct describes the configuration for assertion testing mode.
+      - **Components**:
+        - `enabled`
+          - **Type**: Boolean
+          - **Description**: Enable or disable assertion-based testing
+          - **Default**: `false`
+        - `testViewMethods`
+          - **Type**: Boolean
+          - **Description**: Whether `pure` / `view` functions should be tested for assertion failures.
+          - **Default**: `false`
+        - `assertionModes`
+          - **Type**: Struct
+          - **Description**: This struct describes the various types of EVM-level panics that should be considered a "failing case".
+          - **Components**:
+            - `failOnCOmpilerInsertedPanic`
+              - **Type**: Boolean
+              - **Description**: Triggering a compiler-inserted panic should be treated as a failing case.
+              - **Default**: `false`
+            - `failOnAssertion`
+              - **Type**: Boolean
+              - **Description**: Triggering an assertion failure (e.g. `assert(false)`) should be treated as a failing case.
+              - **Default**: `true`
+            - `failOnArithmeticUnderflow`
+              - **Type**: Boolean
+              - **Description**: Arithmetic underflows or overflows should be treated as a failing case
+              - **Default**: `false`
+            - `failOnDivideByZero`
+              - **Type**: Boolean
+              - **Description**: Dividing by zero should be treated as a failing case
+              - **Default**: `false`
+            - `failOnEnumTypeConversionOutOfBounds`
+              - **Type**: Boolean
+              - **Description**: An out-of-bounds enum access should be treated as a failing case
+              - **Default**: `false`
+            - `failOnIncorrectStorageAccess`
+              - **Type**: Boolean
+              - **Description**: An out-of-bounds storage access should be treated as a failing case
+              - **Default**: `false`
+            - `failOnPopEmptyArray`
+              - **Type**: Boolean
+              - **Description**: A `pop` operation on an empty array should be treated as a failing case
+              - **Default**: `false`
+            - `failOnOutOfBoundsArrayAccess`
+              - **Type**: Boolean
+              - **Description**: An out-of-bounds array access should be treated as a failing case
+              - **Default**: `false`
+            - `failOnAllocateTooMuchMemory`
+              - **Type**: Boolean
+              - **Description**: Overallocation/excessive memory usage should be treated as a failing case
+              - **Default**: `false`
+            - `failOnCallUninitializedVariable`
+              - **Type**: Boolean
+              - **Description**: Calling an unitialized variable should be treated as a failing case
+              - **Default**: `false`
+    - `propertyTesting`
+      - **Type**: Struct
+      - **Description**: This struct describes the configuration for property testing mode.
+      - **Components**:
+        - `enabled`
+          - **Type**: Boolean
+          - **Description**: Enable or disable property-based testing.
+          - **Default**: `true`
+        - `testPrefixes`
+          - **Type**: [String]
+          - **Description**: The list of prefixes that the fuzzer will use to determine whether a given function is a property test or not. For example, if `fuzz_` is a test prefix, then any function name in the form `fuzz_*` may be a property test.
+            > **Note**: If you are moving over from Echidna, you can add `echidna_` as a test prefix to quickly port over the property tests from it.
+          - **Default**: `[fuzz_]`
+    - `optimizationTesting`
+      - **Type**: Struct
+      - **Description**: This struct describes the configuration for optimization testing mode.
+      - **Components**:
+        - `enabled`
+          - **Type**: Boolean
+          - **Description**: Enable or disable optimization testing.
+          - **Default**: `true`
+        - `testPrefixes`
+          - **Type**: [String]
+          - **Description**: The list of prefixes that the fuzzer will use to determine whether a given function is an optimization test or not. For example, if `optimize_` is a test prefix, then any function name in the form `optimize_*` may be a property test.
+          - **Default**: `[optimize_]`
+
+## Compilation Configuration
+
+The compilation configuration defines the parameters to use while compiling a target file or project:
+
+- `platform`
+  - **Type**: String
+  - **Description**: Refers to the type of platform to be used to compile the underlying target. Currently, `crytic-compile` or `solc` can be used as the compilation platform.
+- `platformConfig`
+  - **Type**: Struct
+  - **Description**: This struct is a platform-dependent structure which offers parameters for compiling the underlying project. See below for the structure of `platformConfig` for each compilation platform
+
+> **Note**: The `target` parameter in each `platformConfig` below must be _relative_ paths from the directory containing `medusa`'s project configuration file.
+
+### `platformConfig` for each platform
+
+#### `crytic-compile`
+
+- `target`
+  - **Type**: String
+  - **Description**: Refers to the target that is being compiled. The target can be a single `.sol` file or a whole project (e.g. `hardhat` / `foundry` project).
+- `solcVersion`
+  - **Type**: String
+  - **Description**: Describes the version of `solc` that will be installed and then used for compilation.
+- `exportDirectory`
+  - **Type**: String
+  - **Description**: Describes the directory where all compilation artifacts will be stored.
+- `args`
+  - **Type**: [String]
+  - **Description**: Refers to any additional args that one may want to provide to `crytic-compile`.
+    > 🚩 The `--export-format` and `--export-dir` are already used during compilation with `crytic-compile`. Re-using these flags in `args` will cause the compilation to fail.
+
+#### `solc`
+
+- `target`
+  - **Type**: String
+  - **Description**: Refers to the target that is being compiled. The target must be a single `.sol` file.
+
+## Logging Configuration
+
+The logging configuration defines the parameters for logging to console and/or file:
+
+- `level`
+  - **Type**: String
+  - **Description**: The log level will determine which logs are emitted or discarded. If `level` is "info" then all logs with informational severity or higher will be logged.
+  - **Default**: "info"
+- `logDirectory`
+  - **Type**: String
+  - **Description**: Describes what directory log files should be outputted. Have a non-empty `logDirectory` value will enable "file logging" which will result in logs to be output to both console and file. Note that the directory path is _relative_ to the directory containing `medusa`'s project configuration file.

--- a/docs/src/writing-tests.md
+++ b/docs/src/writing-tests.md
@@ -1,0 +1,189 @@
+# Testing with `medusa`
+
+`medusa`, like Echidna, supports the following testing modes:
+
+1. [Property Mode](https://secure-contracts.com/program-analysis/echidna/introduction/how-to-test-a-property.html)
+2. [Assertion Mode](https://secure-contracts.com/program-analysis/echidna/basic/assertion-checking.html)
+3. [Optimization Mode](https://secure-contracts.com/program-analysis/echidna/advanced/optimization_mode.html)
+
+For more advanced information and documentation on how the various modes work and their pros/cons, check out [secure-contracts.com](https://secure-contracts.com/program-analysis/echidna/index.html)
+
+## Writing property tests
+
+Property tests are represented as functions within a Solidity contract whose names are prefixed with a prefix specified by the `testPrefixes` configuration option (`fuzz_` is the default test prefix). Additionally, they must take no arguments and return a `bool` indicating if the test succeeded.
+
+```solidity
+contract TestXY {
+    uint x;
+    uint y;
+
+    function setX(uint value) public {
+        x = value + 3;
+    }
+
+    function setY(uint value) public {
+        y = value + 9;
+    }
+
+    function fuzz_never_specific_values() public returns (bool) {
+        // ASSERTION: x should never be 10 at the same time y is 80
+        return !(x == 10 && y == 80);
+    }
+}
+```
+
+`medusa` deploys your contract containing property tests and generates a sequence of calls to execute against all publicly accessible methods. After each function call, it calls upon your property tests to ensure they return a `true` (success) status.
+
+### Testing in property-mode
+
+To begin a fuzzing campaign in property-mode, you can run `medusa fuzz` or `medusa fuzz --config [config_path]`.
+
+> **Note**: Learn more about running `medusa` with its CLI [here](./Command-Line-Interface.md).
+
+Invoking this fuzzing campaign, `medusa` will:
+
+- Compile the given targets
+- Start the configured number of worker threads, each with their own local Ethereum test chain.
+- Deploy all contracts to each worker's test chain.
+- Begin to generate and send call sequences to update contract state.
+- Check property tests all succeed after each call executed.
+
+Upon discovery of a failed property test, `medusa` will halt, reporting the call sequence used to violate any property test(s):
+
+```
+[FAILED] Property Test: TestXY.fuzz_never_specific_values()
+Test "TestXY.fuzz_never_specific_values()" failed after the following call sequence:
+1) TestXY.setY([71]) (gas=4712388, gasprice=1, value=0, sender=0x2222222222222222222222222222222222222222)
+2) TestXY.setX([7]) (gas=4712388, gasprice=1, value=0, sender=0x3333333333333333333333333333333333333333)
+```
+
+## Writing assertion tests
+
+Although both property-mode and assertion-mode try to validate / invalidate invariants of the system, they do so in different ways. In property-mode, `medusa` will look for functions with a specific test prefix (e.g. `fuzz_`) and test those. In assertion-mode, `medusa` will test to see if a given call sequence can cause the Ethereum Virtual Machine (EVM) to "panic". The EVM has a variety of panic codes for different scenarios. For example, there is a unique panic code when an `assert(x)` statement returns `false` or when a division by zero is encountered. In assertion mode, which panics should or should not be treated as "failing test cases" can be toggled by updating the [Project Configuration](./Project-Configuration.md#fuzzing-configuration). By default, only `FailOnAssertion` is enabled. Check out the [Example Project Configuration File](https://github.com/crytic/medusa/wiki/Example-Project-Configuration-File) for a visualization of the various panic codes that can be enabled. An explanation of the various panic codes can be found in the [Solidity documentation](https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require).
+
+Please note that the behavior of assertion mode is different between `medusa` and Echidna. Echidna will only test for `assert(x)` statements while `medusa` provides additional flexibility.
+
+```solidity
+contract TestContract {
+    uint x;
+    uint y;
+
+    function setX(uint value) public {
+        x = value;
+
+        // ASSERTION: x should be an even number
+        assert(x % 2 == 0);
+    }
+}
+```
+
+During a call sequence, if `setX` is called with a `value` that breaks the assertion (e.g. `value = 3`), `medusa` will treat this as a failing property and report it back to the user.
+
+### Testing in assertion-mode
+
+To begin a fuzzing campaign in assertion-mode, you can run `medusa fuzz --assertion-mode` or `medusa fuzz --config [config_path] --assertion-mode`.
+
+> **Note**: Learn more about running `medusa` with its CLI [here](./Command-Line-Interface.md).
+
+Invoking this fuzzing campaign, `medusa` will:
+
+- Compile the given targets
+- Start the configured number of worker threads, each with their own local Ethereum test chain.
+- Deploy all contracts to each worker's test chain.
+- Begin to generate and send call sequences to update contract state.
+- Check to see if there any failing assertions after each call executed.
+
+Upon discovery of a failed assertion, `medusa` will halt, reporting the call sequence used to violate any assertions:
+
+```
+Fuzzer stopped, test results follow below ...
+[FAILED] Assertion Test: TestContract.setX(uint256)
+Test for method "TestContract.setX(uint256)" failed after the following call sequence resulted in an assertion:
+1) TestContract.setX([102552480437485684723695021980667056378352338398148431990087576385563741034353]) (block=2, time=4, gas=12500000, gasprice=1, value=0, sender=0x1111111111111111111111111111111111111111)
+```
+
+## Writing optimization tests
+
+Optimization mode's goal is not to validate/invalidate properties but instead to maximize the return value of a function. Similar to property mode, these functions must be prefixed with a prefix specified by the `testPrefixes` configuration option (`optimize_` is the default test prefix). Additionally, they must take no arguments and return an `int256`. A good use case for optimization mode is to try to quantify the impact of a bug (e.g. a rounding error).
+
+```solidity
+contract TestContract {
+    int256 input;
+
+    function set(int256 _input) public {
+        input = _input;
+    }
+
+    function optimize_opt_linear() public view returns (int256) {
+        if (input > -4242) return -input;
+        else return 0;
+    }
+}
+```
+
+`medusa` deploys your contract containing optimization tests and generates a sequence of calls to execute against all publicly accessible methods. After each function call, it calls upon your otpimization tests to identify whether the return value of those tests are greater than the currently stored values.
+
+### Testing in optimization-mode
+
+To begin a fuzzing campaign in optimization-mode, you can run `medusa fuzz --optimization-mode` or `medusa fuzz --config [config_path] --optimization-mode`.
+
+> **Note**: Learn more about running `medusa` with its CLI [here](./Command-Line-Interface.md).
+
+Invoking this fuzzing campaign, `medusa` will:
+
+- Compile the given targets
+- Start the configured number of worker threads, each with their own local Ethereum test chain.
+- Deploy all contracts to each worker's test chain.
+- Begin to generate and send call sequences to update contract state.
+- Check to see if the return value of the optimization test is greater than the cached value.
+  - If the value is greater, update the cached value.
+
+Once the test limit or timeout for the fuzzing campaign has been reached, `medusa` will halt and report the call sequence that maximized the return value of the function:
+
+```
+Fuzzer stopped, test results follow below ...
+[PASSED] Optimization Test: TestContract.optimize_opt_linear()
+Optimization test "TestContract.optimize_opt_linear()" resulted in the maximum value: 4241 with the following sequence:
+1) TestContract.set(-4241) (block=2, time=3, gas=12500000, gasprice=1, value=0, sender=0x0000000000000000000000000000000000010000)
+```
+
+## Testing with multiple modes
+
+Note that we can run `medusa` with one, many, or no modes enabled. Running `medusa fuzz --assertion-mode --optimization-mode` will run all three modes at the same time, since property-mode is enabled by default. If a project configuration file is used, any combination of the three modes can be toggled. In fact, all three modes can be disabled and `medusa` will still run. Please review the [Project Configuration](./Project-Configuration.md) wiki page and the [Project Configuration Example](/Example-Project-Configuration-File.md) for more information.
+
+```solidity
+contract TestContract {
+    int256 input;
+
+    function set(int256 _input) public {
+        input = _input;
+    }
+
+    function failing_assert_method(uint value) public {
+        // ASSERTION: We always fail when you call this function.
+        assert(false);
+    }
+
+    function fuzz_failing_property() public view returns (bool) {
+        // ASSERTION: fail immediately.
+        return false;
+    }
+
+    function optimize_opt_linear() public view returns (int256) {
+        if (input > -4242) return -input;
+        else return 0;
+    }
+}
+```
+
+Invoking a fuzzing campaign with `medusa fuzz --assertion-mode --optimization-mode` (note all three modes are enabled), `medusa` will:
+
+- Compile the given targets
+- Start the configured number of worker threads, each with their own local Ethereum test chain.
+- Deploy all contracts to each worker's test chain.
+- Begin to generate and send call sequences to update contract state.
+- Check to see:
+  - If property tests all succeed after each call executed.
+  - If a panic (which was enabled in the project configuration) has been triggered after each call.
+  - Whether the return value of the optimization test is greater than the cached value.
+    - Update the cached value if it is greater.


### PR DESCRIPTION
Based on this [issue](https://github.com/crytic/medusa/issues/189).

Repo owner needs to enable GitHub Pages and have it point to the /docs folder. The only things I did not do was:

- add logos (didn't work for some reason).
- add a cname in book.toml because I wasn't sure if you guys were interested in using a custom domain.