### PR TITLE
Introduce medusaget as a one-line installation

### DIFF
--- a/medusaget/install
+++ b/medusaget/install
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-set -e
 
 function install_medusaget {
   echo "Downloading medusaget..."
-  curl -# -k -L "$1" -o "$2"
+  curl -# -L "$1" -o "$2"
   chmod +x "$2"
 }
 
@@ -36,7 +35,7 @@ function main {
   base_dir=${XDG_CONFIG_HOME:-$HOME}
   root_dir="$base_dir/.medusa"
   bin_dir="$root_dir/bin"
-  fetch_url="https://raw.githubusercontent.com/crytic/medusa/feat/one-line-install/medusaget/medusaget"
+  fetch_url="https://raw.githubusercontent.com/crytic/medusa/master/medusaget/medusaget"
   fetch_path="$bin_dir/medusaget"
 
   # Create dir & Download medusaget
@@ -47,7 +46,9 @@ function main {
   case "$SHELL" in
     *zsh)  sh_type="zsh"  ;;
     *bash) sh_type="bash" ;;
-    *)     sh_type="unknown" ;;
+    *)
+      echo "Unknown shell. Manually add to PATH."
+      exit 1
   esac
   configure_shell "$sh_type" "$bin_dir"
 
@@ -57,5 +58,5 @@ function main {
   echo "medusaget is ready. Simply run 'medusaget' to get started."
 }
 
-main "$@"
+main"$@"
 

--- a/medusaget/install
+++ b/medusaget/install
@@ -36,7 +36,7 @@ function main {
   base_dir=${XDG_CONFIG_HOME:-$HOME}
   root_dir="$base_dir/.medusa"
   bin_dir="$root_dir/bin"
-  fetch_url="https://raw.githubusercontent.com/zachmdsi/medusa/feat/one-line-install/medusaget/medusaget"
+  fetch_url="https://raw.githubusercontent.com/crytic/medusa/feat/one-line-install/medusaget/medusaget"
   fetch_path="$bin_dir/medusaget"
 
   # Create dir & Download medusaget

--- a/medusaget/install
+++ b/medusaget/install
@@ -1,48 +1,61 @@
 #!/usr/bin/env bash
 set -e
 
-echo Installing medusaget...
+function install_medusaget {
+  echo "Downloading medusaget..."
+  curl -# -k -L "$1" -o "$2"
+  chmod +x "$2"
+}
 
-# Base directories
-BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
-MEDUSA_DIR=${MEDUSA_DIR-"$BASE_DIR/.medusa"}
-MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
+function configure_shell {
+  local shell_type="$1"
+  local bin_path="$2"
 
-# URL for medusaget script
-BIN_URL="https://raw.githubusercontent.com/crytic/medusa/master/medusaget/medusaget"
-BIN_PATH="$MEDUSA_BIN_DIR/medusaget"
+  case "$shell_type" in
+    zsh)
+      echo "export PATH=\$PATH:$bin_path" >> ~/.zshrc
+      ;;
+    bash)
+      echo "export PATH=\$PATH:$bin_path" >> ~/.bashrc
+      ;;
+    *)
+      echo "Unknown shell. Manually add to PATH."
+      exit 1
+      ;;
+  esac
+}
 
-# Create directories if they don't exist
-mkdir -p $MEDUSA_BIN_DIR
+function check_libusb_macos {
+  if [[ ! -f /usr/local/opt/libusb/lib/libusb-1.0.0.dylib && ! -f /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib ]]; then
+    echo "Warning: libusb not found. You may need to install it manually via Homebrew (brew install libusb)."
+  fi
+}
 
-# Download medusaget script
-curl -# -L $BIN_URL -o $BIN_PATH
-chmod +x $BIN_PATH
+function main {
+  # Configurations
+  base_dir=${XDG_CONFIG_HOME:-$HOME}
+  root_dir="$base_dir/.medusa"
+  bin_dir="$root_dir/bin"
+  fetch_url="https://raw.githubusercontent.com/zachmdsi/medusa/feat/one-line-install/medusaget/medusaget"
+  fetch_path="$bin_dir/medusaget"
 
-# Detect shell and update profile
-case $SHELL in
-  */zsh)
-    PROFILE=${ZDOTDIR-"$HOME"}/.zshenv
-    PREF_SHELL=zsh
-    ;;
-  */bash)
-    PROFILE=$HOME/.bashrc
-    PREF_SHELL=bash
-    ;;
-  */fish)
-    PROFILE=$HOME/.config/fish/config.fish
-    PREF_SHELL=fish
-    ;;
-  *)
-    echo "Medusaget: could not detect shell, manually add ${MEDUSA_BIN_DIR} to your PATH."
-    exit 1
-esac
+  # Create dir & Download medusaget
+  mkdir -p "$bin_dir"
+  install_medusaget "$fetch_url" "$fetch_path"
 
-# Add medusaget to PATH if not already present
-if [[ ":$PATH:" != *":${MEDUSA_BIN_DIR}:"* ]]; then
-    echo >> $PROFILE && echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> $PROFILE
-fi
+  # Shell & PATH setup
+  case "$SHELL" in
+    *zsh)  sh_type="zsh"  ;;
+    *bash) sh_type="bash" ;;
+    *)     sh_type="unknown" ;;
+  esac
+  configure_shell "$sh_type" "$bin_dir"
 
-echo "Detected your preferred shell is ${PREF_SHELL} and added medusaget to PATH."
-echo "Run 'source ${PROFILE}' or start a new terminal session to use medusaget."
-echo "Then, simply run 'medusaget' to start using it."
+  # MacOS libusb check
+  [[ "$OSTYPE" =~ ^darwin ]] && check_libusb_macos
+
+  echo "medusaget is ready. Simply run 'medusaget' to get started."
+}
+
+main "$@"
+

--- a/medusaget/install
+++ b/medusaget/install
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
-function install_medusaget {
+install_medusaget() {
   echo "Downloading medusaget..."
   curl -# -L "$1" -o "$2"
   chmod +x "$2"
 }
 
-function configure_shell {
+configure_shell() {
   local shell_type="$1"
   local bin_path="$2"
 
   case "$shell_type" in
-    zsh)
-      echo "export PATH=\$PATH:$bin_path" >> ~/.zshrc
-      ;;
-    bash)
-      echo "export PATH=\$PATH:$bin_path" >> ~/.bashrc
-      ;;
+    zsh)  echo "export PATH=\$PATH:$bin_path" >> ~/.zshrc  ;;
+    bash) echo "export PATH=\$PATH:$bin_path" >> ~/.bashrc ;;
     *)
       echo "Unknown shell. Manually add to PATH."
       exit 1
@@ -24,22 +21,22 @@ function configure_shell {
   esac
 }
 
-function check_libusb_macos {
+check_libusb_macos() {
   if [[ ! -f /usr/local/opt/libusb/lib/libusb-1.0.0.dylib && ! -f /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib ]]; then
     echo "Warning: libusb not found. You may need to install it manually via Homebrew (brew install libusb)."
   fi
 }
 
-function main {
+main() {
   # Configurations
-  base_dir=${XDG_CONFIG_HOME:-$HOME}
-  root_dir="$base_dir/.medusa"
-  bin_dir="$root_dir/bin"
+  base=${XDG_CONFIG_HOME:-$HOME}
+  root="$base/.medusa"
+  bin="$root/bin"
   fetch_url="https://raw.githubusercontent.com/crytic/medusa/master/medusaget/medusaget"
-  fetch_path="$bin_dir/medusaget"
+  fetch_path="$bin/medusaget"
 
   # Create dir & Download medusaget
-  mkdir -p "$bin_dir"
+  mkdir -p "$bin"
   install_medusaget "$fetch_url" "$fetch_path"
 
   # Shell & PATH setup
@@ -50,7 +47,7 @@ function main {
       echo "Unknown shell. Manually add to PATH."
       exit 1
   esac
-  configure_shell "$sh_type" "$bin_dir"
+  configure_shell "$sh_type" "$bin"
 
   # MacOS libusb check
   [[ "$OSTYPE" =~ ^darwin ]] && check_libusb_macos
@@ -58,5 +55,5 @@ function main {
   echo "medusaget is ready. Simply run 'medusaget' to get started."
 }
 
-main"$@"
+main "$@"
 

--- a/medusaget/install
+++ b/medusaget/install
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+
+echo Installing medusaget...
+
+# Base directories
+BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
+MEDUSA_DIR=${MEDUSA_DIR-"$BASE_DIR/.medusa"}
+MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
+
+# URL for medusaget script
+BIN_URL="https://raw.githubusercontent.com/crytic/medusa/master/medusaget/medusaget"
+BIN_PATH="$MEDUSA_BIN_DIR/medusaget"
+
+# Create directories if they don't exist
+mkdir -p $MEDUSA_BIN_DIR
+
+# Download medusaget script
+curl -# -L $BIN_URL -o $BIN_PATH
+chmod +x $BIN_PATH
+
+# Detect shell and update profile
+case $SHELL in
+  */zsh)
+    PROFILE=${ZDOTDIR-"$HOME"}/.zshenv
+    PREF_SHELL=zsh
+    ;;
+  */bash)
+    PROFILE=$HOME/.bashrc
+    PREF_SHELL=bash
+    ;;
+  */fish)
+    PROFILE=$HOME/.config/fish/config.fish
+    PREF_SHELL=fish
+    ;;
+  *)
+    echo "Medusaget: could not detect shell, manually add ${MEDUSA_BIN_DIR} to your PATH."
+    exit 1
+esac
+
+# Add medusaget to PATH if not already present
+if [[ ":$PATH:" != *":${MEDUSA_BIN_DIR}:"* ]]; then
+    echo >> $PROFILE && echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> $PROFILE
+fi
+
+echo "Detected your preferred shell is ${PREF_SHELL} and added medusaget to PATH."
+echo "Run 'source ${PROFILE}' or start a new terminal session to use medusaget."
+echo "Then, simply run 'medusaget' to start using it."

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-set -e # Exit on error
 
 # Display the banner
-banner() {
+function print_banner {
   printf "
 
 =========================================================================================
@@ -32,7 +31,7 @@ Contribute : https://github.com/crytic/medusa/contribute
 }
 
 # Display usage information
-usage() {
+function show_usage {
   cat 1>&2 <<EOF
 The installer for Medusa.
 
@@ -46,158 +45,191 @@ OPTIONS:
     -v, --version   Install a specific version
     -b, --branch    Install a specific branch
     -P, --pr        Install a specific pull request
-    -C, --commit    Install a specific commit
+    -c, --commit    Install a specific commit
     -r, --repo      Install a remote repository
     -p, --path      Install a local repository
 EOF
 }
 
 # Log messages
-say() {
-  echo "medusaget: $1"
+function log {
+  echo "INFO: $1"
 }
 
-# Check if command exists
-need_cmd() {
-  if check_cmd "$1"; then
-    say "need '$1' (command not found)"
-    exit 1
+# Log error and exit
+function error {
+  echo "ERROR: $1"
+  exit 1
+}
+
+# Check for required dependencies 
+function validate_deps {
+  local deps=("go" "git" "pip3" "curl")
+  for cmd in "${deps[@]}"; do
+    if ! command -v $cmd &>/dev/null; then
+      error "Missing $cmd. Exiting."
+    fi
+  done
+}
+
+# Get the go version
+function get_go_version {
+  go version | cut -d ' ' -f3 | tr -d 'go'
+}
+
+# Check that the go version is supported by medusa
+function validate_go_version {
+  local min="1.18"
+  local ver=$(get_go_version)
+  if [[ $ver < $min ]]; then
+    error "Go $min+ required. Exiting."
   fi
 }
 
-# Helper function to check command
-check_cmd() {
-  ! command -v "$1" &>/dev/null
+# Install crytic compile if it isn't available
+function install_crytic_compile {
+  if ! pip3 show crytic-compile &> /dev/null; then
+    pip3 install crytic-compile
+  fi
 }
 
-# Check if Go version is 1.18 or higher
-check_go_version() {
-  local version=$(go version | awk '{print $3}' | tr -d 'go')
-  [[ $(echo "$version 1.18" | awk '{print ($1 >= $2)}') -eq 1 ]]
+# Check for a valid solidity compiler
+function validate_solidity_compiler {
+  local solc=("solc" "hardhat" "truffle" "brownie" "foundry")
+  for cmd in "${solc[@]}"; do
+    if command -v $cmd &>/dev/null; then
+      return 0
+    fi
+  done
+  error "No Solidity compiler found. Exiting."
 }
 
-main() {
-  # Define directories
-  BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
-  MEDUSA_DIR="$BASE_DIR/.medusa"
-  MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
+# Verify platform and architecture
+function check_platform_and_arch {
+  local platform=$(uname -s)
+  local architecture=$(uname -m)
 
-  # Check for required commands
-  need_cmd go   # Go is required to build medusa
-  need_cmd git  # Git is required to clone medusa
-  need_cmd pip3 # pip3 is required to install crytic-compile
+  case $platform in
+    Linux) platform="linux" ;;
+    Darwin) platform="mac" ;;
+    MINGW*) platform="win" ;;
+    *) error "Unsupported platform"; ;;
+  esac
 
+  case $architecture in
+    x86_64) architecture="x64" ;;
+    arm64) architecture="arm64" ;;
+    *) error "Unsupported architecture: $architecture"; ;;
+  esac
+}
+
+function main {
   # Parse command-line arguments
-  while [[ $1 ]]; do
-    case $1 in
-      --version=*|-v=*) MEDUSA_VERSION="${1#*=}" ;;
-      --branch=*|-b=*)  MEDUSA_BRANCH="${1#*=}"  ;;
-      --pr=*|-P=*)      MEDUSA_PR="${1#*=}"      ;;
-      --commit=*|-C=*)  MEDUSA_COMMIT="${1#*=}"  ;;
-      --repo=*|-r=*)    MEDUSA_REPO="${1#*=}"    ;;
-      --path=*|-p=*)    MEDUSA_PATH="${1#*=}"    ;;
+  while (( "$#" )); do
+    case "$1" in
+      -v|--version) version="$2"; shift ;;
+      -b|--branch)  branch="$2";  shift ;;
+      -P|--pr)      pr="$2";      shift ;;
+      -c|--commit)  commit="$2";  shift ;;
+      -r|--repo)    repo="$2";    shift ;;
+      -p|--path)    path="$2";    shift ;;
       --help|-h)
-        usage
+        show_usage
         exit 0
         ;;
-      *)
-        say "unknown option: $1"
-        exit 1
-        ;;
+      *) error "Unknown option: $1. Exiting." ;;
     esac
     shift
   done
 
   # Check for conflicting options
-  if [ -n "$MEDUSA_PR" ] && [ -n "$MEDUSA_BRANCH" ]; then
-    say "cannot specify both --pr and --branch"
-    exit 1
+  if [ -n "$pr" ] && [ -n "$branch" ]; then
+    error "Cannot specify both --pr and --branch. Exiting."
   fi
 
-  # Handle local repository intallation
-  if [ "$MEDUSA_PATH" != "" ]; then
-    say "Installing from local repository: $MEDUSA_PATH"
+  # Pre-requisites
+  check_platform_and_arch
+  validate_deps
+  validate_solidity_compiler
 
-    # Navigate to the local repo and build
-    cd "$MEDUSA_PATH"
-    go build -v -o "$MEDUSA_BIN_DIR/medusa"
-    say "medusa installed."
+  # Setup base directories
+  base_dir="${XDG_CONFIG_HOME:-$HOME}"
+  bin_dir="$base_dir/.medusa/bin"
+  mkdir -p "$bin_dir"
+
+  print_banner
+
+  # Handle local installation if provided
+  if [ "$path" != "" ]; then
+    log "Installing from local repository: $path"
+
+    cd "$path"
+    go build -v -o "$bin_dir/medusa"
+    log "medusa installed."
     exit 0
   fi
 
-  # Display the banner
-  banner
-
-  # Check if Go version is 1.18 or higher
-  if ! check_go_version; then
-    say "Go version 1.18 or higher is required. Exiting."
-    exit 1
-  fi
-
-  # Check if crytic-compile is installed, if not, install it
-  if ! pip3 show crytic-compile &> /dev/null; then
-    say "Installing crytic-compile"
-    pip3 install crytic-compile
-  fi
-
-  # Check for a Solidity compiler
-  if check_cmd solc && check_cmd hardhat && check_cmd truffle && check_cmd brownie && check_cmd foundry; then
-    say "No Solidity compiler found. Exiting."
-    exit 1
-  fi
-
-  # Create the medusa bin directory if it doesn't exist
-  mkdir -p "$MEDUSA_BIN_DIR"
-
-  # Detect platform and architecture
-  PLATFORM=$(uname -s)
-  ARCHITECTURE=$(uname -m)
-
-  case $PLATFORM in
-    Linux) PLATFORM="linux" ;;
-    Darwin) PLATFORM="mac" ;;
-    MINGW*) PLATFORM="win" ;;
-    *) say "Unsupported platform"; e 1 ;;
-  esac
-
-  case $ARCHITECTURE in
-    x86_64) ARCHITECTURE="x64" ;;
-    arm64) ARCHITECTURE="arm64" ;;
-    *) say "Unsupported architecture: $ARCHITECTURE"; exit 1 ;;
-  esac
-
   # Clone medusa repo if it doesn't exist
-  MEDUSA_REPO="https://github.com/crytic/medusa.git"
-  CLONE_DIR="$MEDUSA_DIR/src"
+  repo="https://github.com/crytic/medusa.git"
+  clone_dir="$base_dir/src/medusa"
 
-  if [ ! -d "$CLONE_DIR" ]; then
-    git clone "$MEDUSA_REPO" "$CLONE_DIR"
+  if [ ! -d "$clone_dir" ]; then
+    git clone "$repo" "$clone_dir"
   fi
 
   # Navigate to the medusa repo and fetch updates
-  cd "$CLONE_DIR"
+  cd "$clone_dir"
   git fetch origin
 
-  # Checkout to the specified branch, version, or commit
-  if [ -n "$MEDUSA_COMMIT" ]; then
-    git checkout "$MEDUSA_COMMIT"
-  elif [ -n "$MEDUSA_PR" ]; then
-    git fetch origin pull/$MEDUSA_PR/head:pr$MEDUSA_PR
-    git checkout pr$MEDUSA_PR
-  elif [ -n "$MEDUSA_BRANCH" ]; then
-    git checkout "$MEDUSA_BRANCH"
-  elif [ -n "$MEDUSA_VERSION" ]; then
-    git checkout "tags/$MEDUSA_VERSION"
-  else
-    git checkout master
+  # Save the current active branch
+  active_branch=$(git symbolic-ref HEAD 2>/dev/null | cut -d'/' -f 3)
+
+  # Determine target branch or state based on user options
+  target=""
+  [ -n "$branch" ] && target=$branch
+  [ -n "$pr" ] && target="pr$pr"
+
+  # Pre-fetch the target, but don't checkout
+  if [ -n "$branch" ]; then
+    git fetch origin "$branch"
+  elif [ -n "$pr" ]; then
+    git fetch origin pull/$pr/head:pr$pr
   fi
 
-  # Build medusa
-  go build -v -o "$MEDUSA_BIN_DIR/medusa"
+  # If the active branch is not the one you're about to install, switch to master
+  [ "$active_branch" != "$target" ] && git checkout master
 
-  # Final message
-  say "medusa installed."
+  # Save list of old branches and remove them
+  old_branches=$(git for-each-ref --format '%(refname:short)' refs/heads/)
+  for old in $old_branches; do
+    [ "$old" != "master" ] && git branch -D $old
+  done
+
+  # Now checkout to the target
+  if [ -n "$branch" ]; then
+    git checkout -b "$branch" --track "origin/$branch"
+  elif [ -n "$pr" ]; then
+    git checkout pr$pr
+  elif [ -n "$commit" ]; then
+    git checkout "$commit"
+  fi
+
+  # Append to PATH if not already there
+  add_to_path="export PATH=\$PATH:$bin_dir"
+  case "$SHELL" in
+    */zsh)
+      grep -qF "$add_to_path" ~/.zshrc || echo "$add_to_path" >> ~/.zshrc
+      ;;
+    */bash)
+      grep -qF "$add_to_path" ~/.bashrc || echo "$add_to_path" >> ~/.bashrc
+      ;;
+    *)
+     error "Unknown shell. Manually add to PATH."
+     ;;
+  esac
+
+  log "medusa installed."
 }
 
-# Execture the main function
-main "$@" || exit 1
+main "$@"
+

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e # Exit on error
 
+# Display the banner
 banner() {
   printf "
 
@@ -30,7 +31,7 @@ Contribute : https://github.com/crytic/medusa/contribute
 "
 }
 
-# --help output
+# Display usage information
 usage() {
   cat 1>&2 <<EOF
 The installer for Medusa.
@@ -43,6 +44,11 @@ USAGE:
 OPTIONS:
     -h, --help      Print help information
     -v, --version   Install a specific version
+    -b, --branch    Install a specific branch
+    -P, --pr        Install a specific pull request
+    -C, --commit    Install a specific commit
+    -r, --repo      Install a remote repository
+    -p, --path      Install a local repository
 EOF
 }
 
@@ -64,28 +70,35 @@ check_cmd() {
   ! command -v "$1" &>/dev/null
 }
 
-# Check Go version
+# Check if Go version is 1.18 or higher
 check_go_version() {
   local version=$(go version | awk '{print $3}' | tr -d 'go')
   [[ $(echo "$version 1.18" | awk '{print ($1 >= $2)}') -eq 1 ]]
 }
 
 main() {
+  # Define directories
   BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
   MEDUSA_DIR="$BASE_DIR/.medusa"
   MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
 
-  need_cmd go
-  need_cmd git
-  need_cmd pip3
+  # Check for required commands
+  need_cmd go   # Go is required to build medusa
+  need_cmd git  # Git is required to clone medusa
+  need_cmd pip3 # pip3 is required to install crytic-compile
 
+  # Parse command-line arguments
   while [[ $1 ]]; do
     case $1 in
-      --version=*|-v=*)
-        MEDUSA_VERSION="${1#*=}"
-        ;;
-      --branch=*|-b=*)
-        MEDUSA_BRANCH="${1#*=}"
+      --version=*|-v=*) MEDUSA_VERSION="${1#*=}" ;;
+      --branch=*|-b=*)  MEDUSA_BRANCH="${1#*=}"  ;;
+      --pr=*|-P=*)      MEDUSA_PR="${1#*=}"      ;;
+      --commit=*|-C=*)  MEDUSA_COMMIT="${1#*=}"  ;;
+      --repo=*|-r=*)    MEDUSA_REPO="${1#*=}"    ;;
+      --path=*|-p=*)    MEDUSA_PATH="${1#*=}"    ;;
+      --help|-h)
+        usage
+        exit 0
         ;;
       *)
         say "unknown option: $1"
@@ -95,25 +108,48 @@ main() {
     shift
   done
 
+  # Check for conflicting options
+  if [ -n "$MEDUSA_PR" ] && [ -n "$MEDUSA_BRANCH" ]; then
+    say "cannot specify both --pr and --branch"
+    exit 1
+  fi
+
+  # Handle local repository intallation
+  if [ -n "$MEDUSA_PATH"]; then
+    say "Installing from local repository: $MEDUSA_PATH"
+
+    # Navigate to the local repo and build
+    cd "$MEDUSA_PATH"
+    go build -v -o "$MEDUSA_BIN_DIR/medusa"
+    say "medusa installed. Add $MEDUSA_BIN_DIR to your PATH."
+    exit 0
+  fi
+
+  # Display the banner
   banner
 
+  # Check if Go version is 1.18 or higher
   if ! check_go_version; then
     say "Go version 1.18 or higher is required. Exiting."
     exit 1
   fi
 
+  # Check if crytic-compile is installed, if not, install it
   if ! pip3 show crytic-compile &> /dev/null; then
     say "Installing crytic-compile"
     pip3 install crytic-compile
   fi
 
+  # Check for a Solidity compiler
   if check_cmd solc && check_cmd hardhat && check_cmd truffle && check_cmd brownie && check_cmd foundry; then
     say "No Solidity compiler found. Exiting."
     exit 1
   fi
 
+  # Create the medusa bin directory if it doesn't exist
   mkdir -p "$MEDUSA_BIN_DIR"
 
+  # Detect platform and architecture
   PLATFORM=$(uname -s)
   ARCHITECTURE=$(uname -m)
 
@@ -130,6 +166,7 @@ main() {
     *) say "Unsupported architecture: $ARCHITECTURE"; exit 1 ;;
   esac
 
+  # Clone medusa repo if it doesn't exist
   MEDUSA_REPO="https://github.com/crytic/medusa.git"
   CLONE_DIR="$MEDUSA_DIR/src"
 
@@ -137,10 +174,17 @@ main() {
     git clone "$MEDUSA_REPO" "$CLONE_DIR"
   fi
 
+  # Navigate to the medusa repo and fetch updates
   cd "$CLONE_DIR"
   git fetch origin
 
-  if [ -n "$MEDUSA_BRANCH" ]; then
+  # Checkout to the specified branch, version, or commit
+  if [ -n "$MEDUSA_COMMIT" ]; then
+    git checkout "$MEDUSA_COMMIT"
+  elif [ -n "$MEDUSA_PR" ]; then
+    git fetch origin pull/$MEDUSA_PR/head:pr$MEDUSA_PR
+    git checkout pr$MEDUSA_PR
+  elif [ -n "$MEDUSA_BRANCH" ]; then
     git checkout "$MEDUSA_BRANCH"
   elif [ -n "$MEDUSA_VERSION" ]; then
     git checkout "tags/$MEDUSA_VERSION"
@@ -148,9 +192,12 @@ main() {
     git checkout master
   fi
 
+  # Build medusa
   go build -v -o "$MEDUSA_BIN_DIR/medusa"
 
+  # Final message
   say "medusa installed. Add $MEDUSA_BIN_DIR to your PATH."
 }
 
+# Execture the main function
 main "$@" || exit 1

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -105,7 +105,6 @@ fi
 tar -xzvf $TMP_FILE -C $MEDUSA_BIN_DIR
 rm -f $TMP_FILE
 
-# Add Medusa to PATH if not already present
 PROFILE="$HOME/.bashrc"  # Default to bash
 case $SHELL in
   */zsh)
@@ -119,6 +118,7 @@ case $SHELL in
     ;;
 esac
 
+# Add Medusa to PATH if not already present
 if [[ ":$PATH:" != *":${MEDUSA_BIN_DIR}:"* ]]; then
     echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> $PROFILE
 fi

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
+set -e
 
-# Display the banner
-function print_banner {
+print_flag() {
   printf "
 
 =========================================================================================
@@ -30,12 +30,11 @@ Contribute : https://github.com/crytic/medusa/contribute
 "
 }
 
-# Display usage information
-function show_usage {
+show_help() {
   cat 1>&2 <<EOF
-The installer for Medusa.
+The installer for medusa.
 
-Easily update or install a specific version of Medusa.
+Easily update or install a specific version of medusa.
 
 USAGE:
     medusaget <OPTIONS>
@@ -51,61 +50,37 @@ OPTIONS:
 EOF
 }
 
-# Log messages
-function log {
-  echo "INFO: $1"
-}
+log() { echo "INFO: $1"; }
+error() { echo "ERROR: $1"; exit 1; }
 
-# Log error and exit
-function error {
-  echo "ERROR: $1"
-  exit 1
-}
-
-# Check for required dependencies 
-function validate_deps {
-  local deps=("go" "git" "pip3" "curl")
-  for cmd in "${deps[@]}"; do
+validate_deps() {
+  for cmd in go git pip3 curl; do
     if ! command -v $cmd &>/dev/null; then
-      error "Missing $cmd. Exiting."
+      error "Missing $cmd."
     fi
   done
 }
 
-# Get the go version
-function get_go_version {
-  go version | cut -d ' ' -f3 | tr -d 'go'
+get_go_version() { go version | cut -d ' ' -f3 | tr -d 'go'; }
+
+validate_go_version() {
+  [[ $(get_go_version) < 1.18 ]] && error "Go 1.18+ required."
 }
 
-# Check that the go version is supported by medusa
-function validate_go_version {
-  local min="1.18"
-  local ver=$(get_go_version)
-  if [[ $ver < $min ]]; then
-    error "Go $min+ required. Exiting."
-  fi
+install_crytic_compile() {
+  pip3 show crytic-compile &> /dev/null || pip3 install crytic-compile
 }
 
-# Install crytic compile if it isn't available
-function install_crytic_compile {
-  if ! pip3 show crytic-compile &> /dev/null; then
-    pip3 install crytic-compile
-  fi
-}
-
-# Check for a valid solidity compiler
-function validate_solidity_compiler {
-  local solc=("solc" "hardhat" "truffle" "brownie" "foundry")
-  for cmd in "${solc[@]}"; do
+validate_solidity_compiler() {
+  for cmd in solc hardhat truffle brownie foundry; do
     if command -v $cmd &>/dev/null; then
       return 0
     fi
   done
-  error "No Solidity compiler found. Exiting."
+  error "No Solidity compiler found."
 }
 
-# Verify platform and architecture
-function check_platform_and_arch {
+check_platform_and_arch() {
   local platform=$(uname -s)
   local architecture=$(uname -m)
 
@@ -123,8 +98,8 @@ function check_platform_and_arch {
   esac
 }
 
-function main {
-  # Parse command-line arguments
+main() {
+  # Parse args
   while (( "$#" )); do
     case "$1" in
       -v|--version) version="$2"; shift ;;
@@ -133,78 +108,65 @@ function main {
       -c|--commit)  commit="$2";  shift ;;
       -r|--repo)    repo="$2";    shift ;;
       -p|--path)    path="$2";    shift ;;
-      --help|-h)
-        show_usage
+      -h|--help)
+        show_help
         exit 0
         ;;
-      *) error "Unknown option: $1. Exiting." ;;
+      *) error "Unknown $1"; shift ;;
     esac
     shift
   done
 
-  # Check for conflicting options
-  if [ -n "$pr" ] && [ -n "$branch" ]; then
-    error "Cannot specify both --pr and --branch. Exiting."
+  # Invalid Multiple Targets Check
+  if [ -n "$version" ] || [ -n "$pr" ] || [ -n "$commit" ]; then
+    if [ -n "$repo" ] || [ -n "$branch" ]; then
+      error "Invalid combo. Only --repo and --branch can be combined."
+      exit 1
+    fi
   fi
 
-  # Pre-requisites
-  check_platform_and_arch
-  validate_deps
-  validate_solidity_compiler
-  print_banner
+  # Setup
+  base="${XDG_CONFIG_HOME:-$HOME}"; bin="$base/.medusa/bin"; clone="$base/.medusa/src"
+  mkdir -p "$bin"
+  check_platform_and_arch; validate_deps; validate_solidity_compiler; print_flag 
 
-  # Setup base directories
-  base_dir="${XDG_CONFIG_HOME:-$HOME}"
-  bin_dir="$base_dir/.medusa/bin"
-  mkdir -p "$bin_dir"
-
-  # Handle local installation if provided
-  if [ "$path" != "" ]; then
-    log "Installing from local repository: $path"
-
+  # Install from path
+  if [ -n "$path" ]; then
+    log "Installing local repository at $path"
     cd "$path"
-    go build -v -o "$bin_dir/medusa"
-    log "medusa installed."
+    go build -v -o "$bin/medusa"
     exit 0
   fi
 
-  # Clone medusa repo if it doesn't exist
-  repo="https://github.com/crytic/medusa.git"
-  clone_dir="$base_dir/src/medusa"
+  # Clone medusa repo
+  [ ! -d $clone ] && git clone "${repo:-https://github.com/crytic/medusa.git}" "$clone"
+  cd $clone
 
-  if [ ! -d "$clone_dir" ]; then
-    git clone "$repo" "$clone_dir"
+  # Fetch target
+  remote_url="https://github.com/${repo:-crytic/medusa}.git"
+  git remote set-url origin "$remote_url"
+  fetch_target="${branch:-${pr:+pull/$pr/head:pr$pr}${version:+refs/tags/$version}}"
+  if [ -n "$commit" ]; then
+    git fetch origin
+  elif [ -n "$fetch_target" ]; then
+    git fetch origin $fetch_target
+  else
+    git fetch origin master
   fi
 
-  # Navigate to the medusa repo and fetch updates
-  cd "$clone_dir"
-  git fetch origin
-
-  # Save the current active branch
+  # If the active branch is not the target, switch to master
+  latest_version=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  target="${version:-${branch:-${pr:+pr$pr}${commit:-$latest_version}}}"
   active_branch=$(git symbolic-ref HEAD 2>/dev/null | cut -d'/' -f 3)
-
-  # Determine target branch or state based on user options
-  target=""
-  [ -n "$branch" ] && target=$branch
-  [ -n "$pr" ] && target="pr$pr"
-
-  # Pre-fetch the target, but don't checkout
-  if [ -n "$branch" ]; then
-    git fetch origin "$branch"
-  elif [ -n "$pr" ]; then
-    git fetch origin pull/$pr/head:pr$pr
-  fi
-
-  # Save list of old branches and remove them
+  [ "$active_branch" != "$target" ] && git checkout master
+  
+  # Cleanup old branches
   old_branches=$(git for-each-ref --format '%(refname:short)' refs/heads/)
   for old in $old_branches; do
     [ "$old" != "master" ] && git branch -D $old
   done
 
-  # If the active branch is not the one you're about to install, switch to master
-  [ "$active_branch" != "$target" ] && git checkout master
-
-  # Now checkout to the target
+  # Checkout target
   if [ -n "$branch" ]; then
     git checkout -b "$branch" --track "origin/$branch"
   elif [ -n "$pr" ]; then
@@ -212,24 +174,15 @@ function main {
   elif [ -n "$commit" ]; then
     git checkout "$commit"
   elif [ -n "$version" ]; then
-    git checkout "tags/$version"
+    git checkout "tags/$version" 
   fi
 
-  # Append to PATH if not already there
-  add_to_path="export PATH=\$PATH:$bin_dir"
-  case "$SHELL" in
-    */zsh)
-      grep -qF "$add_to_path" ~/.zshrc || echo "$add_to_path" >> ~/.zshrc
-      ;;
-    */bash)
-      grep -qF "$add_to_path" ~/.bashrc || echo "$add_to_path" >> ~/.bashrc
-      ;;
-    *)
-     error "Unknown shell. Manually add to PATH."
-     ;;
-  esac
+  # Update PATH
+  add="export PATH=\$PATH:$bin"
+  grep -qF "$add" ~/.${SHELL##*/}rc || echo "$add" >> ~/.${SHELL##*/}rc
 
-  go build -v -o "$bin_dir/medusa"
+  # Build
+  go build -v -o "$bin/medusa"
 
   log "medusa installed."
 }

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -e
+
+BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
+MEDUSA_DIR=${MEDUSA_DIR:-"$BASE_DIR/.medusa"}
+MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
+
+need_cmd() {
+  if ! command -v "$1" &>/dev/null; then
+    echo "need '$1' (command not found)"
+    exit 1
+  fi
+}
+
+say() {
+  printf "medusaget: %s\n" "$1"
+}
+
+# Check for prerequisites
+need_cmd go
+need_cmd curl
+need_cmd pip3
+
+# Check Go version
+GO_VERSION=$(go version | awk '{print $3}' | tr -d 'go')
+if [[ $(echo "$GO_VERSION 1.18" | awk '{print ($1 >= $2)}') -ne 1 ]]; then
+    echo "Go version 1.18 or higher is required. Exiting."
+    exit 1
+fi
+
+# Install crytic-compile if not installed
+if ! pip3 show crytic-compile &> /dev/null; then
+    say "Installing crytic-compile"
+    pip3 install crytic-compile
+fi
+
+# Check for solc or hardhat
+if ! command -v solc &> /dev/null && ! command -v hardhat &> /dev/null; then
+    echo "Either solc or hardhat is required but neither is installed. Exiting."
+    exit 1
+fi
+
+# Create directories if they don't exist
+mkdir -p $MEDUSA_BIN_DIR
+
+# Determine platform and architecture
+PLATFORM="$(uname -s)"
+ARCHITECTURE="$(uname -m)"
+EXT="tar.gz"
+
+case $PLATFORM in
+  Linux)
+    PLATFORM="linux"
+    ;;
+  Darwin)
+    PLATFORM="mac"
+    if [ "$ARCHITECTURE" = "arm64" ]; then
+      ARCHITECTURE="arm64"
+    else
+      ARCHITECTURE="x64"
+    fi
+    ;;
+  MINGW*)
+    EXT="tar.gz"
+    PLATFORM="win"
+    ;;
+  *)
+    echo "unsupported platform: $PLATFORM"
+    exit 1
+    ;;
+esac
+
+if [ "$ARCHITECTURE" = "x86_64" ]; then
+  ARCHITECTURE="x64"
+elif [ "$ARCHITECTURE" = "arm64" ]; then
+  ARCHITECTURE="arm64"
+else
+  echo "unsupported architecture: $ARCHITECTURE"
+  exit 1
+fi
+
+get_latest_version() {
+  LATEST_VERSION=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  if [[ -z "$LATEST_VERSION" ]]; then
+    echo "Couldn't get the latest version. Exiting."
+    exit 1
+  fi
+}
+
+# Compute the URL of the release tarball in the Medusa repository.
+get_latest_version
+BIN_URL="https://github.com/crytic/medusa/releases/download/$LATEST_VERSION/medusa-$PLATFORM-$ARCHITECTURE.$EXT"
+
+# Download and extract Medusa
+say "Downloading Medusa..."
+TMP_FILE=$(mktemp)
+curl -L $BIN_URL -o $TMP_FILE
+FILE_TYPE=$(file -b $TMP_FILE)
+
+if [[ $FILE_TYPE != "gzip compressed data"* ]]; then
+  echo "Downloaded file is not a gzip compressed archive. Exiting."
+  exit 1
+fi
+
+tar -xzvf $TMP_FILE -C $MEDUSA_BIN_DIR
+rm -f $TMP_FILE
+
+# Add Medusa to PATH if not already present
+PROFILE="$HOME/.bashrc"  # Default to bash
+case $SHELL in
+  */zsh)
+    PROFILE="$HOME/.zshrc"
+    ;;
+  */bash)
+    PROFILE="$HOME/.bashrc"
+    ;;
+  */fish)
+    PROFILE="$HOME/.config/fish/config.fish"
+    ;;
+esac
+
+if [[ ":$PATH:" != *":${MEDUSA_BIN_DIR}:"* ]]; then
+    echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> $PROFILE
+fi
+
+say "Medusa installed. Run 'source $PROFILE' or start a new terminal session to use it."

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -30,6 +30,22 @@ Contribute : https://github.com/crytic/medusa/contribute
 "
 }
 
+# --help output
+usage() {
+  cat 1>&2 <<EOF
+The installer for Medusa.
+
+Easily update or install a specific version of Medusa.
+
+USAGE:
+    medusaget <OPTIONS>
+
+OPTIONS:
+    -h, --help      Print help information
+    -v, --version   Install a specific version
+EOF
+}
+
 # Log messages
 say() {
   echo "medusaget: $1"
@@ -55,36 +71,49 @@ check_go_version() {
 }
 
 main() {
-  # Define directories
   BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
-  MEDUSA_DIR=${MEDUSA_DIR:-"$BASE_DIR/.medusa"}
+  MEDUSA_DIR="$BASE_DIR/.medusa"
   MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
 
   need_cmd go
+  need_cmd git
   need_cmd pip3
 
-  # Check Go version
+  while [[ $1 ]]; do
+    case $1 in
+      --version=*|-v=*)
+        MEDUSA_VERSION="${1#*=}"
+        ;;
+      --branch=*|-b=*)
+        MEDUSA_BRANCH="${1#*=}"
+        ;;
+      *)
+        say "unknown option: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  banner
+
   if ! check_go_version; then
     say "Go version 1.18 or higher is required. Exiting."
     exit 1
   fi
 
-  # Install crytic-compile if not installed
   if ! pip3 show crytic-compile &> /dev/null; then
     say "Installing crytic-compile"
     pip3 install crytic-compile
   fi
 
-  # Check for a Solidity compiler
   if check_cmd solc && check_cmd hardhat && check_cmd truffle && check_cmd brownie && check_cmd foundry; then
     say "No Solidity compiler found. Exiting."
     exit 1
   fi
 
-  # Create medusa bin directory
   mkdir -p "$MEDUSA_BIN_DIR"
 
-  # Detect platform and architecture
   PLATFORM=$(uname -s)
   ARCHITECTURE=$(uname -m)
 
@@ -92,7 +121,7 @@ main() {
     Linux) PLATFORM="linux" ;;
     Darwin) PLATFORM="mac" ;;
     MINGW*) PLATFORM="win" ;;
-    *) say "Unsupported platform"; exit 1 ;;
+    *) say "Unsupported platform"; e 1 ;;
   esac
 
   case $ARCHITECTURE in
@@ -101,85 +130,27 @@ main() {
     *) say "Unsupported architecture: $ARCHITECTURE"; exit 1 ;;
   esac
 
-  # Parse command-line-arguments
-  VERSION="latest"
+  MEDUSA_REPO="https://github.com/crytic/medusa.git"
+  CLONE_DIR="$MEDUSA_DIR/src"
 
-  for arg in "$@"; do
-    case $arg in
-      --version=*)
-        VERSION="${arg#*=}"
-        shift
-        ;;
-      *)
-        say "Invalid option: $arg"
-        exit 1
-        ;;
-    esac
-  done
-
-  # Fetch the latest version if not specified
-  if [ "$VERSION" == "latest" ]; then
-    VERSION=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  if [ ! -d "$CLONE_DIR" ]; then
+    git clone "$MEDUSA_REPO" "$CLONE_DIR"
   fi
 
-  [[ -z "$VERSION" ]] && say "Couldn't get the specified version. Exiting." && exit 1
+  cd "$CLONE_DIR"
+  git fetch origin
 
-  # Initialize BIN_URL
-  BIN_URL="https://github.com/crytic/medusa/releases/download/$VERSION/medusa-$PLATFORM-$ARCHITECTURE.tar.gz"
-
-  # Fetch asset URLs
-  need_cmd curl
-  ASSETS_JSON=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/tags/$VERSION" | grep -o 'https://[^"]*')
-
-  if [[ $? -ne 0 ]]; then
-    say "Failed to fetch asset URL. Exiting."
-    exit 1
+  if [ -n "$MEDUSA_BRANCH" ]; then
+    git checkout "$MEDUSA_BRANCH"
+  elif [ -n "$MEDUSA_VERSION" ]; then
+    git checkout "tags/$MEDUSA_VERSION"
+  else
+    git checkout master
   fi
 
-  # Loop through assets to find correct URL
-  for asset in $ASSETS_JSON; do
-    if [[ $asset == "$PLATFORM-$ARCHITECTURE.tar.gz"* ]]; then
-      BIN_URL=$asset
-      break
-    elif [[ $asset == *"$PLATFORM-$ARCHITECTURE.zip"* ]]; then
-      BIN_URL=$asset
-      break
-    fi
-  done
+  go build -v -o "$MEDUSA_BIN_DIR/medusa"
 
-  # Download and extract medusa
-  need_cmd tar
-  need_cmd unzip
-  say "Downloading medusa..."
-  TMP_FILE=$(mktemp)
-  curl -L $BIN_URL -o "$TMP_FILE"
-
-  case $BIN_URL in
-    *.tar.gz)
-      tar -xzvf "$TMP_FILE" -C "$MEDUSA_BIN_DIR"
-      ;;
-    *.zip)
-      unzip "$TMP_FILE" -d "$MEDUSA_BIN_DIR"
-      ;;
-    *)
-      say "Unsupported file type. Exiting."
-      exit 1
-      ;;
-  esac
-
-  rm -f "$TMP_FILE"
-
-  # Detect shell and update PATH in user's profile
-  PROFILE="$HOME/.bashrc"
-  case $SHELL in
-    */zsh) PROFILE="$HOME/.zshrc" ;;
-    */fish) PROFILE="$HOME/.config/fish/config.fish" ;;
-  esac
-
-  [[ ":$PATH:" != *":${MEDUSA_BIN_DIR}:"* ]] && echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> "$PROFILE"
-
-  say "medusa installed. Run 'source $PROFILE' or start a new terminal session to use it."
-  banner
+  say "medusa installed. Add $MEDUSA_BIN_DIR to your PATH."
 }
 
 main "$@" || exit 1

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -151,13 +151,12 @@ function main {
   check_platform_and_arch
   validate_deps
   validate_solidity_compiler
+  print_banner
 
   # Setup base directories
   base_dir="${XDG_CONFIG_HOME:-$HOME}"
   bin_dir="$base_dir/.medusa/bin"
   mkdir -p "$bin_dir"
-
-  print_banner
 
   # Handle local installation if provided
   if [ "$path" != "" ]; then
@@ -196,14 +195,14 @@ function main {
     git fetch origin pull/$pr/head:pr$pr
   fi
 
-  # If the active branch is not the one you're about to install, switch to master
-  [ "$active_branch" != "$target" ] && git checkout master
-
   # Save list of old branches and remove them
   old_branches=$(git for-each-ref --format '%(refname:short)' refs/heads/)
   for old in $old_branches; do
     [ "$old" != "master" ] && git branch -D $old
   done
+
+  # If the active branch is not the one you're about to install, switch to master
+  [ "$active_branch" != "$target" ] && git checkout master
 
   # Now checkout to the target
   if [ -n "$branch" ]; then
@@ -212,6 +211,8 @@ function main {
     git checkout pr$pr
   elif [ -n "$commit" ]; then
     git checkout "$commit"
+  elif [ -n "$version" ]; then
+    git checkout "tags/$version"
   fi
 
   # Append to PATH if not already there
@@ -227,6 +228,8 @@ function main {
      error "Unknown shell. Manually add to PATH."
      ;;
   esac
+
+  go build -v -o "$bin_dir/medusa"
 
   log "medusa installed."
 }

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -32,8 +32,8 @@ if ! pip3 show crytic-compile &> /dev/null; then
   pip3 install crytic-compile
 fi
 
-if ! command -v solc &> /dev/null && ! command -v hardhat &> /dev/null; then
-  echo "Either solc or hardhat is required but neither is installed. Exiting."
+if ! command -v solc &> /dev/null && ! command -v hardhat &> /dev/null && ! command -v truffle &> /dev/null && ! command -v brownie &> /dev/null && ! command -v foundry &> /dev/null; then
+  echo "No Solidity compiler found. Exiting."
   exit 1
 fi
 

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -1,85 +1,185 @@
 #!/usr/bin/env bash
-set -e
+set -e # Exit on error
 
-# Define directories and utility functions
-BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
-MEDUSA_DIR=${MEDUSA_DIR:-"$BASE_DIR/.medusa"}
-MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
+banner() {
+  printf "
 
-need_cmd() {
-  if ! command -v "$1" &>/dev/null; then
-    echo "need '$1' (command not found)"
-    exit 1
-  fi
+=========================================================================================
+
+  __  __          _
+ |  \/  |        | |        ____
+ | \  / | ___  __| | _   _ / ___/  ____   
+ | |\/| |/ _ \/ _  || | | |\___ \ /    |
+ | |  | |  __/ (_| || |_| | ___) || () |     
+ |_|  |_|\___|\____| \___/ |____/ |_/|_|
+
+ 
+      Parallelized, coverage-guided, mutational Solidity smart contract fuzzing.
+
+
+==========================================================================================
+
+Repo       : https://github.com/crytic/medusa/
+License    : AGPL-3.0
+Latest     : $(curl --silent "https://api.github.com/repos/crytic/medusa/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+Support    : https://github.com/crytic/medusa/issues
+Contribute : https://github.com/crytic/medusa/contribute
+
+==========================================================================================
+
+"
 }
 
+# Log messages
 say() {
   echo "medusaget: $1"
 }
 
-need_cmd go
-need_cmd curl
-need_cmd pip3
+# Check if command exists
+need_cmd() {
+  if check_cmd "$1"; then
+    say "need '$1' (command not found)"
+    exit 1
+  fi
+}
 
-GO_VERSION=$(go version | awk '{print $3}' | tr -d 'go')
-if [[ $(echo "$GO_VERSION 1.18" | awk '{print ($1 >= $2)}') -ne 1 ]]; then
-  echo "Go version 1.18 or higher is required. Exiting."
-  exit 1
-fi
+# Helper function to check command
+check_cmd() {
+  ! command -v "$1" &>/dev/null
+}
 
-if ! pip3 show crytic-compile &> /dev/null; then
-  say "Installing crytic-compile"
-  pip3 install crytic-compile
-fi
+# Check Go version
+check_go_version() {
+  local version=$(go version | awk '{print $3}' | tr -d 'go')
+  [[ $(echo "$version 1.18" | awk '{print ($1 >= $2)}') -eq 1 ]]
+}
 
-if ! command -v solc &> /dev/null && ! command -v hardhat &> /dev/null && ! command -v truffle &> /dev/null && ! command -v brownie &> /dev/null && ! command -v foundry &> /dev/null; then
-  echo "No Solidity compiler found. Exiting."
-  exit 1
-fi
+main() {
+  # Define directories
+  BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
+  MEDUSA_DIR=${MEDUSA_DIR:-"$BASE_DIR/.medusa"}
+  MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
 
-mkdir -p $MEDUSA_BIN_DIR
+  need_cmd go
+  need_cmd pip3
 
-PLATFORM="$(uname -s)"
-ARCHITECTURE="$(uname -m)"
+  # Check Go version
+  if ! check_go_version; then
+    say "Go version 1.18 or higher is required. Exiting."
+    exit 1
+  fi
 
-case $PLATFORM in
-  Linux) PLATFORM="linux" ;;
-  Darwin) PLATFORM="mac" ;;
-  MINGW*) PLATFORM="win" ;;
-  *) say "Unsupported platform"; exit 1 ;;
-esac
+  # Install crytic-compile if not installed
+  if ! pip3 show crytic-compile &> /dev/null; then
+    say "Installing crytic-compile"
+    pip3 install crytic-compile
+  fi
 
-if [ "$ARCHITECTURE" = "x86_64" ]; then
-  ARCHITECTURE="x64"
-elif [ "$ARCHITECTURE" = "arm64" ]; then
-  ARCHITECTURE="arm64"
-else
-  echo "unsupported architecture: $ARCHITECTURE"
-  exit 1
-fi
+  # Check for a Solidity compiler
+  if check_cmd solc && check_cmd hardhat && check_cmd truffle && check_cmd brownie && check_cmd foundry; then
+    say "No Solidity compiler found. Exiting."
+    exit 1
+  fi
 
-LATEST_VERSION=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-if [[ -z "$LATEST_VERSION" ]]; then
-  say "Couldn't get the latest version. Exiting."
-  exit 1
-fi
+  # Create medusa bin directory
+  mkdir -p "$MEDUSA_BIN_DIR"
 
-BIN_URL="https://github.com/crytic/medusa/releases/download/$LATEST_VERSION/medusa-$PLATFORM-$ARCHITECTURE.tar.gz"
+  # Detect platform and architecture
+  PLATFORM=$(uname -s)
+  ARCHITECTURE=$(uname -m)
 
-say "Downloading Medusa..."
-TMP_FILE=$(mktemp)
-curl -L $BIN_URL -o $TMP_FILE
-tar -xzvf $TMP_FILE -C $MEDUSA_BIN_DIR
-rm -f $TMP_FILE
+  case $PLATFORM in
+    Linux) PLATFORM="linux" ;;
+    Darwin) PLATFORM="mac" ;;
+    MINGW*) PLATFORM="win" ;;
+    *) say "Unsupported platform"; exit 1 ;;
+  esac
 
-PROFILE="$HOME/.bashrc"
-case $SHELL in
-  */zsh) PROFILE="$HOME/.zshrc" ;;
-  */fish) PROFILE="$HOME/.config/fish/config.fish" ;;
-esac
+  case $ARCHITECTURE in
+    x86_64) ARCHITECTURE="x64" ;;
+    arm64) ARCHITECTURE="arm64" ;;
+    *) say "Unsupported architecture: $ARCHITECTURE"; exit 1 ;;
+  esac
 
-if [[ ":$PATH:" != *":${MEDUSA_BIN_DIR}:"* ]]; then
-  echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> $PROFILE
-fi
+  # Parse command-line-arguments
+  VERSION="latest"
 
-say "Medusa installed. Run 'source $PROFILE' or start a new terminal session to use it."
+  for arg in "$@"; do
+    case $arg in
+      --version=*)
+        VERSION="${arg#*=}"
+        shift
+        ;;
+      *)
+        say "Invalid option: $arg"
+        exit 1
+        ;;
+    esac
+  done
+
+  # Fetch the latest version if not specified
+  if [ "$VERSION" == "latest" ]; then
+    VERSION=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  fi
+
+  [[ -z "$VERSION" ]] && say "Couldn't get the specified version. Exiting." && exit 1
+
+  # Initialize BIN_URL
+  BIN_URL="https://github.com/crytic/medusa/releases/download/$VERSION/medusa-$PLATFORM-$ARCHITECTURE.tar.gz"
+
+  # Fetch asset URLs
+  need_cmd curl
+  ASSETS_JSON=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/tags/$VERSION" | grep -o 'https://[^"]*')
+
+  if [[ $? -ne 0 ]]; then
+    say "Failed to fetch asset URL. Exiting."
+    exit 1
+  fi
+
+  # Loop through assets to find correct URL
+  for asset in $ASSETS_JSON; do
+    if [[ $asset == "$PLATFORM-$ARCHITECTURE.tar.gz"* ]]; then
+      BIN_URL=$asset
+      break
+    elif [[ $asset == *"$PLATFORM-$ARCHITECTURE.zip"* ]]; then
+      BIN_URL=$asset
+      break
+    fi
+  done
+
+  # Download and extract medusa
+  need_cmd tar
+  need_cmd unzip
+  say "Downloading medusa..."
+  TMP_FILE=$(mktemp)
+  curl -L $BIN_URL -o "$TMP_FILE"
+
+  case $BIN_URL in
+    *.tar.gz)
+      tar -xzvf "$TMP_FILE" -C "$MEDUSA_BIN_DIR"
+      ;;
+    *.zip)
+      unzip "$TMP_FILE" -d "$MEDUSA_BIN_DIR"
+      ;;
+    *)
+      say "Unsupported file type. Exiting."
+      exit 1
+      ;;
+  esac
+
+  rm -f "$TMP_FILE"
+
+  # Detect shell and update PATH in user's profile
+  PROFILE="$HOME/.bashrc"
+  case $SHELL in
+    */zsh) PROFILE="$HOME/.zshrc" ;;
+    */fish) PROFILE="$HOME/.config/fish/config.fish" ;;
+  esac
+
+  [[ ":$PATH:" != *":${MEDUSA_BIN_DIR}:"* ]] && echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> "$PROFILE"
+
+  say "medusa installed. Run 'source $PROFILE' or start a new terminal session to use it."
+  banner
+}
+
+main "$@" || exit 1

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -115,13 +115,13 @@ main() {
   fi
 
   # Handle local repository intallation
-  if [ -n "$MEDUSA_PATH"]; then
+  if [ "$MEDUSA_PATH" != "" ]; then
     say "Installing from local repository: $MEDUSA_PATH"
 
     # Navigate to the local repo and build
     cd "$MEDUSA_PATH"
     go build -v -o "$MEDUSA_BIN_DIR/medusa"
-    say "medusa installed. Add $MEDUSA_BIN_DIR to your PATH."
+    say "medusa installed."
     exit 0
   fi
 
@@ -196,7 +196,7 @@ main() {
   go build -v -o "$MEDUSA_BIN_DIR/medusa"
 
   # Final message
-  say "medusa installed. Add $MEDUSA_BIN_DIR to your PATH."
+  say "medusa installed."
 }
 
 # Execture the main function

--- a/medusaget/medusaget
+++ b/medusaget/medusaget
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# Define directories and utility functions
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 MEDUSA_DIR=${MEDUSA_DIR:-"$BASE_DIR/.medusa"}
 MEDUSA_BIN_DIR="$MEDUSA_DIR/bin"
@@ -13,61 +14,39 @@ need_cmd() {
 }
 
 say() {
-  printf "medusaget: %s\n" "$1"
+  echo "medusaget: $1"
 }
 
-# Check for prerequisites
 need_cmd go
 need_cmd curl
 need_cmd pip3
 
-# Check Go version
 GO_VERSION=$(go version | awk '{print $3}' | tr -d 'go')
 if [[ $(echo "$GO_VERSION 1.18" | awk '{print ($1 >= $2)}') -ne 1 ]]; then
-    echo "Go version 1.18 or higher is required. Exiting."
-    exit 1
+  echo "Go version 1.18 or higher is required. Exiting."
+  exit 1
 fi
 
-# Install crytic-compile if not installed
 if ! pip3 show crytic-compile &> /dev/null; then
-    say "Installing crytic-compile"
-    pip3 install crytic-compile
+  say "Installing crytic-compile"
+  pip3 install crytic-compile
 fi
 
-# Check for solc or hardhat
 if ! command -v solc &> /dev/null && ! command -v hardhat &> /dev/null; then
-    echo "Either solc or hardhat is required but neither is installed. Exiting."
-    exit 1
+  echo "Either solc or hardhat is required but neither is installed. Exiting."
+  exit 1
 fi
 
-# Create directories if they don't exist
 mkdir -p $MEDUSA_BIN_DIR
 
-# Determine platform and architecture
 PLATFORM="$(uname -s)"
 ARCHITECTURE="$(uname -m)"
-EXT="tar.gz"
 
 case $PLATFORM in
-  Linux)
-    PLATFORM="linux"
-    ;;
-  Darwin)
-    PLATFORM="mac"
-    if [ "$ARCHITECTURE" = "arm64" ]; then
-      ARCHITECTURE="arm64"
-    else
-      ARCHITECTURE="x64"
-    fi
-    ;;
-  MINGW*)
-    EXT="tar.gz"
-    PLATFORM="win"
-    ;;
-  *)
-    echo "unsupported platform: $PLATFORM"
-    exit 1
-    ;;
+  Linux) PLATFORM="linux" ;;
+  Darwin) PLATFORM="mac" ;;
+  MINGW*) PLATFORM="win" ;;
+  *) say "Unsupported platform"; exit 1 ;;
 esac
 
 if [ "$ARCHITECTURE" = "x86_64" ]; then
@@ -79,48 +58,28 @@ else
   exit 1
 fi
 
-get_latest_version() {
-  LATEST_VERSION=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-  if [[ -z "$LATEST_VERSION" ]]; then
-    echo "Couldn't get the latest version. Exiting."
-    exit 1
-  fi
-}
-
-# Compute the URL of the release tarball in the Medusa repository.
-get_latest_version
-BIN_URL="https://github.com/crytic/medusa/releases/download/$LATEST_VERSION/medusa-$PLATFORM-$ARCHITECTURE.$EXT"
-
-# Download and extract Medusa
-say "Downloading Medusa..."
-TMP_FILE=$(mktemp)
-curl -L $BIN_URL -o $TMP_FILE
-FILE_TYPE=$(file -b $TMP_FILE)
-
-if [[ $FILE_TYPE != "gzip compressed data"* ]]; then
-  echo "Downloaded file is not a gzip compressed archive. Exiting."
+LATEST_VERSION=$(curl --silent "https://api.github.com/repos/crytic/medusa/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+if [[ -z "$LATEST_VERSION" ]]; then
+  say "Couldn't get the latest version. Exiting."
   exit 1
 fi
 
+BIN_URL="https://github.com/crytic/medusa/releases/download/$LATEST_VERSION/medusa-$PLATFORM-$ARCHITECTURE.tar.gz"
+
+say "Downloading Medusa..."
+TMP_FILE=$(mktemp)
+curl -L $BIN_URL -o $TMP_FILE
 tar -xzvf $TMP_FILE -C $MEDUSA_BIN_DIR
 rm -f $TMP_FILE
 
-PROFILE="$HOME/.bashrc"  # Default to bash
+PROFILE="$HOME/.bashrc"
 case $SHELL in
-  */zsh)
-    PROFILE="$HOME/.zshrc"
-    ;;
-  */bash)
-    PROFILE="$HOME/.bashrc"
-    ;;
-  */fish)
-    PROFILE="$HOME/.config/fish/config.fish"
-    ;;
+  */zsh) PROFILE="$HOME/.zshrc" ;;
+  */fish) PROFILE="$HOME/.config/fish/config.fish" ;;
 esac
 
-# Add Medusa to PATH if not already present
 if [[ ":$PATH:" != *":${MEDUSA_BIN_DIR}:"* ]]; then
-    echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> $PROFILE
+  echo "export PATH=\"\$PATH:$MEDUSA_BIN_DIR\"" >> $PROFILE
 fi
 
 say "Medusa installed. Run 'source $PROFILE' or start a new terminal session to use it."


### PR DESCRIPTION
Based on [this](https://github.com/crytic/medusa/issues/205)

All that's needed is to host the install script somewhere so you can install `medusaget` with a simple curl command:

```bash
curl -L https://your-install-script-url | bash
```

Then run `medusaget` for a one-line installation.

Pretty much mimics `foundryup`'s process. There is no support for Windows users so they must use WSL or Git Bash.