### PR TITLE
Fail on revert/require feature

### DIFF
--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -132,6 +132,8 @@ type AssertionTestingConfig struct {
 // AssertionModesConfig describes the configuration options for the various modes that can be enabled for assertion
 // testing
 type AssertionModesConfig struct {
+	// FailOnRevert describes whether a revert should be treated as a failing case
+	FailOnRevert bool `json:"failOnRevert"`
 	// FailOnCompilerInsertedPanic describes whether a generic compiler inserted panic should be treated as a failing case
 	FailOnCompilerInsertedPanic bool `json:"failOnCompilerInsertedPanic"`
 

--- a/fuzzing/test_case_assertion_provider.go
+++ b/fuzzing/test_case_assertion_provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/crytic/medusa/fuzzing/config"
 	"github.com/crytic/medusa/fuzzing/contracts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"golang.org/x/exp/slices"
 	"sync"
 )
@@ -70,6 +71,13 @@ func (t *AssertionTestCaseProvider) checkAssertionFailures(callSequence calls.Ca
 	// want to be backwards compatible with older Solidity which simply hit an invalid opcode and did not actually
 	// have a panic code.
 	lastExecutionResult := lastCall.ChainReference.MessageResults().ExecutionResult
+
+	// Check for revert or require failures if FailOnRevert is set to true
+	if t.fuzzer.config.Fuzzing.Testing.AssertionTesting.AssertionModes.FailOnRevert {
+		if lastExecutionResult.Err == vm.ErrExecutionReverted {
+			return &methodId, true, nil
+		}
+	}
 	panicCode := abiutils.GetSolidityPanicCode(lastExecutionResult.Err, lastExecutionResult.ReturnData, true)
 	failure := false
 	if panicCode != nil {

--- a/fuzzing/testdata/contracts/assertions/assert_fail_on_revert.sol
+++ b/fuzzing/testdata/contracts/assertions/assert_fail_on_revert.sol
@@ -1,0 +1,22 @@
+// This contract ensures the fuzzer will report an error when it encounters a revert.
+contract TestContract {
+    function failRequire(uint value) public {
+        // This should trigger a test failure due to a failing require statement (without an error message)
+        require(false);
+    }
+
+    function failRequireWithErrorString(uint value) public {
+        // This should trigger a test failure due to a failing require statement (with an error message)
+        require(false, "Require error");
+    }
+
+    function failRevert(uint value) public {
+        // This should trigger a test failure on encountering a revert instruction (without an error message)
+        revert();
+    }
+
+    function failRevertWithErrorString(uint value) public {
+        // This should trigger a test failure on encountering a revert instruction (with an error message)
+        revert("Function reverted");
+    }
+}


### PR DESCRIPTION
This PR aim to fix issue #192, it introduces a new config option `FailOnRevert` which is disabled by default.
When enabled, a test will result in failure if a `revert` instruction or a`require` condition failure is encountered.