### PR TITLE
Fix CI for Python 3.12 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip3 install --no-cache-dir solc-select crytic-compile
+          pip3 install --no-cache-dir setuptools solc-select crytic-compile
 
       - name: Install solc
         run: |


### PR DESCRIPTION
As we move to Python 3.12 in the CI, packages like `pkg_resources` are not available by default and thus `pip install setuptools` must be run explicitly. 

https://docs.python.org/3/whatsnew/3.12.html