### PR TITLE
shrinking experiment

### DIFF
--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -470,7 +470,7 @@ func defaultCallSequenceGeneratorConfigFunc(fuzzer *Fuzzer, valueSet *valuegener
 func defaultShrinkingValueMutatorFunc(fuzzer *Fuzzer, valueSet *valuegeneration.ValueSet, randomProvider *rand.Rand) (valuegeneration.ValueMutator, error) {
 	// Create the shrinking value mutator for the worker.
 	shrinkingValueMutatorConfig := &valuegeneration.ShrinkingValueMutatorConfig{
-		ShrinkValueProbability: 0.1,
+		ShrinkValueProbability: 1,
 	}
 	shrinkingValueMutator := valuegeneration.NewShrinkingValueMutator(shrinkingValueMutatorConfig, valueSet, randomProvider)
 	return shrinkingValueMutator, nil

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -391,12 +391,10 @@ func (fw *FuzzerWorker) testShrunkenCallSequence(possibleShrunkSequence calls.Ca
 func (fw *FuzzerWorker) shrinkParam(callSequence *calls.CallSequence) {
 	i := fw.randomProvider.Intn(len(*callSequence))
 	abiValuesMsgData := (*callSequence)[i].Call.DataAbiValues
-	j := fw.randomProvider.Intn(len(abiValuesMsgData.InputValues))
-	// for j := 0; j < len(abiValuesMsgData.InputValues); j++ {
-	mutatedInput, _ := valuegeneration.MutateAbiValue(fw.sequenceGenerator.config.ValueGenerator, fw.shrinkingValueMutator, &abiValuesMsgData.Method.Inputs[j].Type, abiValuesMsgData.InputValues[j])
-	(*abiValuesMsgData).InputValues[j] = mutatedInput
-	// }
-	(*callSequence)[i].Call.DataAbiValues = abiValuesMsgData
+	for j := 0; j < len(abiValuesMsgData.InputValues); j++ {
+		mutatedInput, _ := valuegeneration.MutateAbiValue(fw.sequenceGenerator.config.ValueGenerator, fw.shrinkingValueMutator, &abiValuesMsgData.Method.Inputs[j].Type, abiValuesMsgData.InputValues[j])
+		abiValuesMsgData.InputValues[j] = mutatedInput
+	}
 }
 
 func (fw *FuzzerWorker) shorten(callSequence *calls.CallSequence) {

--- a/fuzzing/valuegeneration/mutator_shrinking.go
+++ b/fuzzing/valuegeneration/mutator_shrinking.go
@@ -1,10 +1,11 @@
 package valuegeneration
 
 import (
-	"github.com/crytic/medusa/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"math/rand"
+
+	"github.com/crytic/medusa/utils"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // ShrinkingValueMutator represents a ValueMutator used to shrink function inputs and call arguments.
@@ -96,7 +97,9 @@ func (g *ShrinkingValueMutator) MutateBytes(b []byte) []byte {
 	randomGeneratorDecision := g.randomProvider.Float32()
 	if randomGeneratorDecision < g.config.ShrinkValueProbability {
 		// Mutate the data for our desired number of rounds
+
 		input := bytesShrinkingMethods[g.randomProvider.Intn(len(bytesShrinkingMethods))](g, b)
+
 		return input
 	}
 	return b
@@ -181,6 +184,10 @@ var stringShrinkingMethods = []func(*ShrinkingValueMutator, string) string{
 		// Otherwise, remove a random character.
 		i := g.randomProvider.Intn(len(s))
 		return s[:i] + s[i+1:]
+	},
+	// ???
+	func(g *ShrinkingValueMutator, s string) string {
+		return ""
 	},
 }
 


### PR DESCRIPTION
There's some weird bug where `validShrunkSequence` is true but it doesn't update the `optimizedSequence`.
When I run `./medusa fuzz --target fuzzing/testdata/contracts/value_generation/match_structs_xy.sol --workers 1` and print the sequence, it's not updating even if it's more "minimized" 