### PR TITLE
Throw error when an invalid CLI flag is provided to medusa fuzz

### DIFF
--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -22,7 +22,7 @@ var fuzzCmd = &cobra.Command{
 	ValidArgsFunction: cmdValidFuzzArgs,
 	RunE:              cmdRunFuzz,
 	SilenceUsage:      true,
-	SilenceErrors:     true,
+	SilenceErrors:     false,
 }
 
 func init() {


### PR DESCRIPTION
I changed the **SilenceErrors** field in the medusa fuzz command from `false` to `true`. This way, if an invalid flag is provided to `medusa fuzz`, it doesn't just fail silently but prints an error message indicating that an invalid flag was provided.