### PR TITLE
Fix OOM bug

### DIFF
--- a/chain/test_chain.go
+++ b/chain/test_chain.go
@@ -199,6 +199,14 @@ func NewTestChain(genesisAlloc core.GenesisAlloc, testChainConfig *config.TestCh
 	return chain, nil
 }
 
+// Close will release any objects from the TestChain that must be _explicitly_ released. Currently, the one object that
+// must be explicitly released is the stateDB trie's underlying cache. This cache, if not released, prevents the TestChain
+// object from being freed by the garbage collector and causes a severe memory leak.
+func (t *TestChain) Close() {
+	// Reset the state DB's cache
+	t.stateDatabase.TrieDB().ResetCache()
+}
+
 // Clone recreates the current TestChain state into a new instance. This simply reconstructs the block/chain state
 // but does not perform any other API-related changes such as adding additional tracers the original had. Additionally,
 // this does not clone pending blocks. The provided method, if non-nil, is used as callback to provide an intermediate

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -532,6 +532,9 @@ func (fw *FuzzerWorker) run(baseTestChain *chain.TestChain) (bool, error) {
 		return false, err
 	}
 
+	// Defer the closing of the test chain object
+	defer fw.chain.Close()
+
 	// Emit an event indicating the worker has setup its chain.
 	err = fw.Events.FuzzerWorkerChainSetup.Publish(FuzzerWorkerChainSetupEvent{
 		Worker: fw,

--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/crytic/medusa-geth v0.0.0-20230811005223-cee04520a2f9
+replace github.com/ethereum/go-ethereum => github.com/crytic/medusa-geth v0.0.0-20240209160711-dfded09070ca

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crytic/medusa-geth v0.0.0-20230811005223-cee04520a2f9 h1:BUuL3h23IdVSmyq3I7LVUYRInKgXShMLKElYaFgn4RM=
-github.com/crytic/medusa-geth v0.0.0-20230811005223-cee04520a2f9/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
+github.com/crytic/medusa-geth v0.0.0-20240209160711-dfded09070ca h1:oGRWjrs9pStgFbnk1K5aLTQoY/aeO5zkzqADZH/maFw=
+github.com/crytic/medusa-geth v0.0.0-20240209160711-dfded09070ca/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -396,6 +396,8 @@ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220405052023-b1e9470b6e64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
There existed an OOM bug due to the use of go-ethereum stateDB trie's cache. This cache does not have an eviction policy and thus will persist in memory until explicitly reset or wiped through its API (see [Limitations](https://github.com/VictoriaMetrics/fastcache?tab=readme-ov-file#limitations) in the fastCache documentation).

Thus, any objects that reference this cache, the stateDB (which in turn means the `TestChain`), will never get wiped from the heap by Go's garbage collector. 

Note that we do not want to get _rid_ of caching since it leads to magnitude improvements in throughput. Thus, the fix is two-fold:
1. We had to update `medusa-geth` to have an exposed function that would allow `medusa` to directly reset the fast cache. See this [commit](https://github.com/crytic/medusa-geth/commit/dfded09070caf04b31525996d2245a72cbf9bfd4).
2. We have to now explicitly reset the cache before the `FuzzerWorker` is destroyed. This PR achieves that capability.

This PR closes #249, #237 and #200.

Note that this PR should also lead to performance improvements for long-term medusa runs since memory consumption is now more efficient. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved resource management in testing environments by adding cleanup methods to prevent memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->