### PR TITLE
Fix a non-deterministic copy-length based panic in the parseBytes32 cheatcode

### DIFF
--- a/chain/standard_cheat_code_contract.go
+++ b/chain/standard_cheat_code_contract.go
@@ -452,7 +452,7 @@ func getStandardCheatCodeContract(tracer *cheatCodeTracer) (*CheatCodeContract, 
 
 			// Use a fixed array and copy the data over
 			var bArray [32]byte
-			copy(bArray[:], bSlice[:32])
+			copy(bArray[:], bSlice)
 
 			return []any{bArray}, nil
 		},


### PR DESCRIPTION
The `parseBytes32` cheatcode takes a string as input, casts it to a slice (`[]byte`), and then proceeds to do a copy operation into a 32-byte array (`[32]byte`).
https://github.com/crytic/medusa/blob/62b648c16053d87e3244dfd14a55371059be701c/chain/standard_cheat_code_contract.go#L449-L455

However, it does not just perform a copy, but slices the input slice with `bSlice[:32]`. Yet even in our unit test we test this method by copying "medusa", a string less than 32-bytes.

Although you'd think this would trigger a panic, it doesn't. In Go, you can successfully slice more elements from a slice than the length of the slice itself. Think of it like a block of memory, where capacity is the size of the whole block, and length is what we're using of it. 

More importantly, the capacity of the slice would be non-deterministic unless it was allocated with an explicit capacity (e.g. specified with `b := make([]byte, length, capacity)`. So in this case, you'd happen to just have a capacity of 32-bytes on your byte slice, even though its length was less, and this would not panic.

TLDR: There was a `b[:32]` on a slice with `len(b) < 32`. It wouldn't always panic because slicing in Go does not consider length as much as capacity.
