### PR TITLE
Fix corpus call method resolution bug, improve startup logging

### DIFF
--- a/fuzzing/calls/call_sequence.go
+++ b/fuzzing/calls/call_sequence.go
@@ -205,7 +205,17 @@ func (cse *CallSequenceElement) Method() (*abi.Method, error) {
 	if cse.Contract == nil {
 		return nil, nil
 	}
-	return cse.Contract.CompiledContract().Abi.MethodById(cse.Call.Data)
+
+	// If we have a method resolved, return it.
+	if cse.Call != nil && cse.Call.DataAbiValues != nil {
+		if cse.Call.DataAbiValues.Method != nil {
+			return cse.Call.DataAbiValues.Method, nil
+		}
+	}
+
+	// Try to resolve the method by ID from the call data.
+	method, err := cse.Contract.CompiledContract().Abi.MethodById(cse.Call.Data)
+	return method, err
 }
 
 // String returns a displayable string representing the CallSequenceElement.

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -513,8 +513,7 @@ func (f *Fuzzer) spawnWorkersLoop(baseTestChain *chain.TestChain) error {
 	// Define a flag that indicates whether we have not cancelled o
 	working := !utils.CheckContextDone(f.ctx)
 
-	// Log that we are about to create the workers and start fuzzing
-	f.logger.Info("Creating ", colors.Bold, f.config.Fuzzing.Workers, colors.Reset, " workers...")
+	// Create workers and start fuzzing.
 	var err error
 	for err == nil && working {
 		// Send an item into our channel to queue up a spot. This will block us if we hit capacity until a worker
@@ -617,6 +616,7 @@ func (f *Fuzzer) Start() error {
 	}
 
 	// Set up the corpus
+	f.logger.Info("Initializing corpus")
 	f.corpus, err = corpus.NewCorpus(f.config.Fuzzing.CorpusDirectory)
 	if err != nil {
 		f.logger.Error("Failed to create the corpus", err)
@@ -640,6 +640,7 @@ func (f *Fuzzer) Start() error {
 	}
 
 	// Set it up with our deployment/setup strategy defined by the fuzzer.
+	f.logger.Info("Setting up base chain")
 	err = f.Hooks.ChainSetupFunc(f, baseTestChain)
 	if err != nil {
 		f.logger.Error("Failed to initialize the test chain", err)
@@ -647,11 +648,27 @@ func (f *Fuzzer) Start() error {
 	}
 
 	// Initialize our coverage maps by measuring the coverage we get from the corpus.
-	err = f.corpus.Initialize(baseTestChain, f.contractDefinitions)
+	var corpusActiveSequences, corpusTotalSequences int
+	f.logger.Info("Initializing and validating corpus call sequences")
+	corpusActiveSequences, corpusTotalSequences, err = f.corpus.Initialize(baseTestChain, f.contractDefinitions)
 	if err != nil {
 		f.logger.Error("Failed to initialize the corpus", err)
 		return err
 	}
+
+	// Log corpus health statistics, if we have any existing sequences.
+	if corpusTotalSequences > 0 {
+		f.logger.Info(
+			colors.Bold, "corpus: ", colors.Reset,
+			"health: ", colors.Bold, int(float32(corpusActiveSequences)/float32(corpusTotalSequences)*100.0), "%", colors.Reset, ", ",
+			"valid seqs: ", colors.Bold, corpusActiveSequences, colors.Reset, ", ",
+			"invalid seqs: ", colors.Bold, corpusTotalSequences-corpusActiveSequences, colors.Reset, ", ",
+			"total seqs: ", colors.Bold, corpusTotalSequences, colors.Reset,
+		)
+	}
+
+	// Log the start of our fuzzing campaign.
+	f.logger.Info("Fuzzing with ", colors.Bold, f.config.Fuzzing.Workers, colors.Reset, " workers")
 
 	// Start our printing loop now that we're about to begin fuzzing.
 	go f.printMetricsLoop()

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -661,9 +661,7 @@ func (f *Fuzzer) Start() error {
 		f.logger.Info(
 			colors.Bold, "corpus: ", colors.Reset,
 			"health: ", colors.Bold, int(float32(corpusActiveSequences)/float32(corpusTotalSequences)*100.0), "%", colors.Reset, ", ",
-			"valid seqs: ", colors.Bold, corpusActiveSequences, colors.Reset, ", ",
-			"invalid seqs: ", colors.Bold, corpusTotalSequences-corpusActiveSequences, colors.Reset, ", ",
-			"total seqs: ", colors.Bold, corpusTotalSequences, colors.Reset,
+			"sequences: ", colors.Bold, corpusTotalSequences, " (", corpusActiveSequences, " valid, ", corpusTotalSequences-corpusActiveSequences, " invalid)", colors.Reset,
 		)
 	}
 


### PR DESCRIPTION
This PR should close #287 . The behavior noted in that issue should not have passed through corpus call sequence replay + validation. However, there were two methods for resolving/fetching the `*abi.Method` associated to a `CallSequenceElement`/`CallMessageDataAbiValues`, and the logic deviated between corpus replay and fuzzer workers.

This resolved it by ensuring the `CallSequenceElement.Method()` function returns the `CallMessageDataAbiValues.Method` if it exists.

It also makes the following changes:
- Deprecated `CallMessageDataAbiValues.methodName` in corpus. 
  - When replaying a call sequence in the corpus, a contract would be resolved, and it's ABI would be searched through for the method by method name. 
  - However, this does not support overloaded functions (same name, different signature). This is still read in and attempted to be used to resolve methods if newer methods fail (see next bullet point). 
  - It should be removed after some time passes and corpuses no longer use it. It is no longer serialized. Only deserialized.
  - Replaced with a `methodSignature` field.
- Added more logging to fuzzer startup to indicate where time is being spent.
- Added a log for basic corpus health metrics (valid/invalid/total corpus call sequences and health %).
- Reorder logging to avoid "Creating X workers" message being output after the "fuzz: elapsed[...]" message.

Note: In the future, the way I calculate active/total sequences in corpus should probably be done another way (not returned by the corpus initialize function), we can flag the `corpusFile` objects with an `invalid` (bool) field, and then add a method to loop through and "clean" them. Maybe add a `--clean-corpus` flag or something to remove invalid corpus items from disk :shrug: 