### PR TITLE
Output non-fuzzing failure related error messages

### DIFF
--- a/cmd/exitcodes/error_with_exit_code.go
+++ b/cmd/exitcodes/error_with_exit_code.go
@@ -17,21 +17,25 @@ func NewErrorWithExitCode(err error, exitCode int) *ErrorWithExitCode {
 
 // Error returns the error message string, implementing the `error` interface.
 func (e *ErrorWithExitCode) Error() string {
+	if e.err == nil {
+		return ""
+	}
 	return e.err.Error()
 }
 
-// GetErrorExitCode checks the given exit code that the application should exit with, if this error is bubbled to
-// the top-level. This will be 0 for a nil error, 1 for a generic error, or arbitrary if the error is of type
+// GetInnerErrorAndExitCode checks the given exit code that the application should exit with, if this error is bubbled
+// to the top-level. This will be 0 for a nil error, 1 for a generic error, or arbitrary if the error is of type
 // ErrorWithExitCode.
-// Returns the exit code associated with the error.
-func GetErrorExitCode(err error) int {
+// Returns the error (or inner error if it is an ErrorWithExitCode error type), along with the exit code associated
+// with the error.
+func GetInnerErrorAndExitCode(err error) (error, int) {
 	// If we have no error, return 0, if we have a generic error, return 1, if we have a custom error code, unwrap
 	// and return it.
 	if err == nil {
-		return ExitCodeSuccess
+		return nil, ExitCodeSuccess
 	} else if unwrappedErr, ok := err.(*ErrorWithExitCode); ok {
-		return unwrappedErr.exitCode
+		return unwrappedErr.err, unwrappedErr.exitCode
 	} else {
-		return ExitCodeGeneralError
+		return err, ExitCodeGeneralError
 	}
 }

--- a/cmd/exitcodes/exit_codes.go
+++ b/cmd/exitcodes/exit_codes.go
@@ -16,9 +16,9 @@ const (
 	// ================================
 	// Note: Despite not being standardized, exit codes 2-5 are often used for common use cases, so we avoid them.
 
-	// ExitCodeFuzzerError indicates that there was an error during the execution of a fuzzer. Note that an error with
-	// error code ExitCodeGeneralError and ExitCodeFuzzerError are mutually exclusive errors
-	ExitCodeFuzzerError = 6
+	// ExitCodeHandledError indicates that there was an error that was logged already and does not need to be handled
+	// by main.
+	ExitCodeHandledError = 6
 
 	// ExitCodeTestFailed indicates a test case had failed.
 	ExitCodeTestFailed = 7

--- a/cmd/exitcodes/exit_codes.go
+++ b/cmd/exitcodes/exit_codes.go
@@ -16,6 +16,10 @@ const (
 	// ================================
 	// Note: Despite not being standardized, exit codes 2-5 are often used for common use cases, so we avoid them.
 
+	// ExitCodeFuzzerError indicates that there was an error during the execution of a fuzzer. Note that an error with
+	// error code ExitCodeGeneralError and ExitCodeFuzzerError are mutually exclusive errors
+	ExitCodeFuzzerError = 6
+
 	// ExitCodeTestFailed indicates a test case had failed.
 	ExitCodeTestFailed = 7
 )

--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -147,7 +147,7 @@ func cmdRunFuzz(cmd *cobra.Command, args []string) error {
 	// Create our fuzzing
 	fuzzer, fuzzErr := fuzzing.NewFuzzer(*projectConfig)
 	if fuzzErr != nil {
-		return exitcodes.NewErrorWithExitCode(fuzzErr, exitcodes.ExitCodeFuzzerError)
+		return exitcodes.NewErrorWithExitCode(fuzzErr, exitcodes.ExitCodeHandledError)
 	}
 
 	// Stop our fuzzing on keyboard interrupts
@@ -161,7 +161,7 @@ func cmdRunFuzz(cmd *cobra.Command, args []string) error {
 	// Start the fuzzing process with our cancellable context.
 	fuzzErr = fuzzer.Start()
 	if fuzzErr != nil {
-		return exitcodes.NewErrorWithExitCode(fuzzErr, exitcodes.ExitCodeFuzzerError)
+		return exitcodes.NewErrorWithExitCode(fuzzErr, exitcodes.ExitCodeHandledError)
 	}
 
 	// If we have no error and failed test cases, we'll want to return a special exit code

--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -145,9 +145,9 @@ func cmdRunFuzz(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create our fuzzing
-	fuzzer, err := fuzzing.NewFuzzer(*projectConfig)
-	if err != nil {
-		return err
+	fuzzer, fuzzErr := fuzzing.NewFuzzer(*projectConfig)
+	if fuzzErr != nil {
+		return exitcodes.NewErrorWithExitCode(fuzzErr, exitcodes.ExitCodeFuzzerError)
 	}
 
 	// Stop our fuzzing on keyboard interrupts
@@ -159,7 +159,10 @@ func cmdRunFuzz(cmd *cobra.Command, args []string) error {
 	}()
 
 	// Start the fuzzing process with our cancellable context.
-	err = fuzzer.Start()
+	fuzzErr = fuzzer.Start()
+	if fuzzErr != nil {
+		return exitcodes.NewErrorWithExitCode(fuzzErr, exitcodes.ExitCodeFuzzerError)
+	}
 
 	// If we have no error and failed test cases, we'll want to return a special exit code
 	if err == nil && len(fuzzer.TestCasesWithStatus(fuzzing.TestCaseStatusFailed)) > 0 {

--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -165,9 +165,9 @@ func cmdRunFuzz(cmd *cobra.Command, args []string) error {
 	}
 
 	// If we have no error and failed test cases, we'll want to return a special exit code
-	if err == nil && len(fuzzer.TestCasesWithStatus(fuzzing.TestCaseStatusFailed)) > 0 {
-		return exitcodes.NewErrorWithExitCode(err, exitcodes.ExitCodeTestFailed)
+	if fuzzErr == nil && len(fuzzer.TestCasesWithStatus(fuzzing.TestCaseStatusFailed)) > 0 {
+		return exitcodes.NewErrorWithExitCode(fuzzErr, exitcodes.ExitCodeTestFailed)
 	}
 
-	return err
+	return fuzzErr
 }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	err, exitCode = exitcodes.GetInnerErrorAndExitCode(err)
 
 	// If we have an error, print it.
-	if err != nil {
+	if err != nil && exitCode != exitcodes.ExitCodeFuzzerError {
 		fmt.Println(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ func main() {
 
 	// If we have a special (non-zero/success) error code, then exit with it.
 	exitCode := exitcodes.GetErrorExitCode(err)
-	if exitCode != 0 {
+	if exitCode != exitcodes.ExitCodeSuccess {
 		fmt.Println(err.Error())
 		os.Exit(exitCode)
 	}

--- a/main.go
+++ b/main.go
@@ -11,10 +11,17 @@ func main() {
 	// Run our root CLI command, which contains all underlying command logic and will handle parsing/invocation.
 	err := cmd.Execute()
 
-	// If we have a special (non-zero/success) error code, then exit with it.
-	exitCode := exitcodes.GetErrorExitCode(err)
+	// Obtain the actual error and exit code from the error, if any.
+	var exitCode int
+	err, exitCode = exitcodes.GetInnerErrorAndExitCode(err)
+
+	// If we have an error, print it.
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// If we have a non-success exit code, exit with it.
 	if exitCode != exitcodes.ExitCodeSuccess {
-		fmt.Println(err.Error())
 		os.Exit(exitCode)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	err, exitCode = exitcodes.GetInnerErrorAndExitCode(err)
 
 	// If we have an error, print it.
-	if err != nil && exitCode != exitcodes.ExitCodeFuzzerError {
+	if err != nil && exitCode != exitcodes.ExitCodeHandledError {
 		fmt.Println(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/crytic/medusa/cmd"
 	"github.com/crytic/medusa/cmd/exitcodes"
 	"os"
@@ -10,6 +11,10 @@ func main() {
 	// Run our root CLI command, which contains all underlying command logic and will handle parsing/invocation.
 	err := cmd.Execute()
 
-	// Determine the exit code from any potential error and exit out.
-	os.Exit(exitcodes.GetErrorExitCode(err))
+	// If we have a special (non-zero/success) error code, then exit with it.
+	exitCode := exitcodes.GetErrorExitCode(err)
+	if exitCode != 0 {
+		fmt.Println(err.Error())
+		os.Exit(exitCode)
+	}
 }


### PR DESCRIPTION
If you input a bad command/argument, the error is not displayed. This is because `main.go` never does print it. This fixes that issue.

This prints the error if any had occurred. Question for you @anishnaik , do you think this should instead use the global logger? We could do that now or in the future (if it's not a big concern).