### PR TITLE
fix: use the shrunken abi values as the msg's data

### DIFF
--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -10,6 +10,7 @@ import (
 	fuzzerTypes "github.com/crytic/medusa/fuzzing/contracts"
 	"github.com/crytic/medusa/fuzzing/coverage"
 	"github.com/crytic/medusa/fuzzing/valuegeneration"
+	"github.com/crytic/medusa/logging"
 	"github.com/crytic/medusa/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/exp/maps"
@@ -465,6 +466,13 @@ func (fw *FuzzerWorker) shrinkCallSequence(callSequence calls.CallSequence, shri
 					}
 					abiValuesMsgData.InputValues[j] = mutatedInput
 				}
+
+				// Re-encode the ABI values as calldata.
+				abiData, err := abiValuesMsgData.Pack()
+				if err != nil {
+					logging.GlobalLogger.Panic("Failed to pack call message ABI values", err)
+				}
+				possibleShrunkSequence[i].Call.Data = abiData
 
 				// Test the shrunken sequence.
 				validShrunkSequence, err := fw.testShrunkenCallSequence(possibleShrunkSequence, shrinkRequest)


### PR DESCRIPTION
During input shrinking, the msg's data was not being re-encoded so there were duplicate entires in the `test_results` directory that seemed unique based on their `inputValues` field but had the same `data` field.

Closes https://github.com/crytic/medusa/issues/338