### PR TITLE
Fix wrong links in the doc + update command in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ To install
 To run
 
 - `prettier '**.json' '**/*.md' '**/*.yml' '!(pkg)'`
-- `markdown-link-check --config .github/workflows/resources/markdown_link_check.json ./*.md`
+- `find . -name '*.md' -print0 | xargs -0 -n1 markdown-link-check --config .github/workflows/resources/markdown_link_check.json`
 
 To format (overwrite files)
 

--- a/docs/src/project_configuration/overview.md
+++ b/docs/src/project_configuration/overview.md
@@ -43,7 +43,7 @@ value to `10_000` or `100_000` depending on the use case. You can learn more abo
 Updating the corpus directory is optional but recommended. The corpus directory determines where corpus items should be
 stored on disk. A corpus item is a sequence of transactions that increased `medusa`'s coverage of the system. Thus, these
 corpus items are valuable to store so that they can be re-used for the next fuzzing campaign. Additionally, the directory
-will also hold [coverage reports](TODO) which is a valuable tool for debugging and validation. For most cases, you may set
+will also hold [coverage reports](../coverage_reports.md) which is a valuable tool for debugging and validation. For most cases, you may set
 `corpusDirectory`'s value to "corpus". This will create a `corpus/` directory in the same directory as the `medusa.json`
 file.
 You can learn more about this option [here](./fuzzing_config.md#corpusdirectory).

--- a/docs/src/project_configuration/testing_config.md
+++ b/docs/src/project_configuration/testing_config.md
@@ -59,7 +59,7 @@ contract MyContract {
 ### `traceAll`:
 
 - **Type**: Boolean
-- **Description**: Determines whether an [execution trace](TODO) should be attached to each element of a call sequence
+- **Description**: Determines whether an `execution trace` should be attached to each element of a call sequence
   that triggered a test failure.
 - **Default**: `false`
 

--- a/docs/src/testing/writing-tests.md
+++ b/docs/src/testing/writing-tests.md
@@ -38,7 +38,7 @@ contract TestXY {
 
 To begin a fuzzing campaign in property-mode, you can run `medusa fuzz` or `medusa fuzz --config [config_path]`.
 
-> **Note**: Learn more about running `medusa` with its CLI [here](./Command-Line-Interface.md).
+> **Note**: Learn more about running `medusa` with its CLI [here](../cli/overview.md).
 
 Invoking this fuzzing campaign, `medusa` will:
 
@@ -59,7 +59,7 @@ Test "TestXY.fuzz_never_specific_values()" failed after the following call seque
 
 ## Writing assertion tests
 
-Although both property-mode and assertion-mode try to validate / invalidate invariants of the system, they do so in different ways. In property-mode, `medusa` will look for functions with a specific test prefix (e.g. `fuzz_`) and test those. In assertion-mode, `medusa` will test to see if a given call sequence can cause the Ethereum Virtual Machine (EVM) to "panic". The EVM has a variety of panic codes for different scenarios. For example, there is a unique panic code when an `assert(x)` statement returns `false` or when a division by zero is encountered. In assertion mode, which panics should or should not be treated as "failing test cases" can be toggled by updating the [Project Configuration](./Project-Configuration.md#fuzzing-configuration). By default, only `FailOnAssertion` is enabled. Check out the [Example Project Configuration File](https://github.com/crytic/medusa/wiki/Example-Project-Configuration-File) for a visualization of the various panic codes that can be enabled. An explanation of the various panic codes can be found in the [Solidity documentation](https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require).
+Although both property-mode and assertion-mode try to validate / invalidate invariants of the system, they do so in different ways. In property-mode, `medusa` will look for functions with a specific test prefix (e.g. `fuzz_`) and test those. In assertion-mode, `medusa` will test to see if a given call sequence can cause the Ethereum Virtual Machine (EVM) to "panic". The EVM has a variety of panic codes for different scenarios. For example, there is a unique panic code when an `assert(x)` statement returns `false` or when a division by zero is encountered. In assertion mode, which panics should or should not be treated as "failing test cases" can be toggled by updating the [Project Configuration](../project_configuration/fuzzing_config.md#fuzzing-configuration). By default, only `FailOnAssertion` is enabled. Check out the [Example Project Configuration File](https://github.com/crytic/medusa/wiki/Example-Project-Configuration-File) for a visualization of the various panic codes that can be enabled. An explanation of the various panic codes can be found in the [Solidity documentation](https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require).
 
 Please note that the behavior of assertion mode is different between `medusa` and Echidna. Echidna will only test for `assert(x)` statements while `medusa` provides additional flexibility.
 
@@ -83,7 +83,7 @@ During a call sequence, if `setX` is called with a `value` that breaks the asser
 
 To begin a fuzzing campaign in assertion-mode, you can run `medusa fuzz --assertion-mode` or `medusa fuzz --config [config_path] --assertion-mode`.
 
-> **Note**: Learn more about running `medusa` with its CLI [here](./Command-Line-Interface.md).
+> **Note**: Learn more about running `medusa` with its CLI [here](../cli/overview.md).
 
 Invoking this fuzzing campaign, `medusa` will:
 
@@ -127,7 +127,7 @@ contract TestContract {
 
 To begin a fuzzing campaign in optimization-mode, you can run `medusa fuzz --optimization-mode` or `medusa fuzz --config [config_path] --optimization-mode`.
 
-> **Note**: Learn more about running `medusa` with its CLI [here](./Command-Line-Interface.md).
+> **Note**: Learn more about running `medusa` with its CLI [here](../cli/overview.md).
 
 Invoking this fuzzing campaign, `medusa` will:
 
@@ -149,7 +149,7 @@ Optimization test "TestContract.optimize_opt_linear()" resulted in the maximum v
 
 ## Testing with multiple modes
 
-Note that we can run `medusa` with one, many, or no modes enabled. Running `medusa fuzz --assertion-mode --optimization-mode` will run all three modes at the same time, since property-mode is enabled by default. If a project configuration file is used, any combination of the three modes can be toggled. In fact, all three modes can be disabled and `medusa` will still run. Please review the [Project Configuration](./Project-Configuration.md) wiki page and the [Project Configuration Example](/Example-Project-Configuration-File.md) for more information.
+Note that we can run `medusa` with one, many, or no modes enabled. Running `medusa fuzz --assertion-mode --optimization-mode` will run all three modes at the same time, since property-mode is enabled by default. If a project configuration file is used, any combination of the three modes can be toggled. In fact, all three modes can be disabled and `medusa` will still run. Please review the [Project Configuration](https://github.com/crytic/medusa/wiki/Project-Configuration) wiki page and the [Project Configuration Example](https://github.com/crytic/medusa/wiki/Example-Project-Configuration-File) for more information.
 
 ```solidity
 contract TestContract {


### PR DESCRIPTION
I think we should also update the CI

https://github.com/crytic/medusa/blob/9a2d0d9f895c74b168047b37f825e7d2b4079d41/.github/workflows/ci.yml#L144-L147

As this only checks for markdown files within the top level directory 

We can probably just use the one from buidling secure contracts: https://github.com/crytic/building-secure-contracts/blob/master/.github/workflows/lint_links.yml

What do you think?