### PR TITLE
Fix panic when execution tracing cheatcode contracts

### DIFF
--- a/chain/test_chain.go
+++ b/chain/test_chain.go
@@ -9,7 +9,6 @@ import (
 	"github.com/crytic/medusa/chain/config"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/ethereum/go-ethereum/triedb/hashdb"
 	"github.com/holiman/uint256"
@@ -256,7 +255,7 @@ func (t *TestChain) Clone(onCreateFunc func(chain *TestChain) error) (*TestChain
 		// Now add each transaction/message to it.
 		messages := t.blocks[i].Messages
 		for j := 0; j < len(messages); j++ {
-			err = targetChain.PendingBlockAddTx(messages[j], nil)
+			err = targetChain.PendingBlockAddTx(messages[j])
 			if err != nil {
 				return nil, err
 			}
@@ -728,15 +727,7 @@ func (t *TestChain) PendingBlockCreateWithParameters(blockNumber uint64, blockTi
 // PendingBlockAddTx takes a message (internal txs) and adds it to the current pending block, updating the header
 // with relevant execution information. If a pending block was not created, an error is returned.
 // Returns an error if one occurred.
-func (t *TestChain) PendingBlockAddTx(message *core.Message, getTracerFn func(txIndex int, txHash common.Hash) *tracers.Tracer) error {
-	// Caller can specify any tracer they wish to use for this transaction
-	if getTracerFn == nil {
-		// TODO: Figure out whether it is possible to identify _which_ transaction you want to trace (versus all)
-		getTracerFn = func(txIndex int, txHash common.Hash) *tracers.Tracer {
-			return t.transactionTracerRouter.NativeTracer().Tracer
-		}
-	}
-
+func (t *TestChain) PendingBlockAddTx(message *core.Message, additionalTracers ...*TestChainTracer) error {
 	// If we don't have a pending block, return an error
 	if t.pendingBlock == nil {
 		return errors.New("could not add tx to the chain's pending block because no pending block was created")
@@ -757,11 +748,19 @@ func (t *TestChain) PendingBlockAddTx(message *core.Message, getTracerFn func(tx
 		ConfigExtensions: t.vmConfigExtensions,
 	}
 
-	// Set the tracer to be used in the vm config
-	tracer := getTracerFn(len(t.pendingBlock.Messages), tx.Hash())
-	if tracer != nil {
-		vmConfig.Tracer = tracer.Hooks
+	// Figure out whether we need to attach any more tracers
+	var extendedTracerRouter *TestChainTracerRouter
+	if len(additionalTracers) > 0 {
+		// If we have more tracers, extend the transaction tracer router's tracers with additional ones
+		extendedTracerRouter = NewTestChainTracerRouter()
+		extendedTracerRouter.AddTracer(t.transactionTracerRouter.NativeTracer())
+		t.transactionTracerRouter.AddTracers(additionalTracers...)
+	} else {
+		extendedTracerRouter = t.transactionTracerRouter
 	}
+
+	// Update the VM's tracer
+	vmConfig.Tracer = extendedTracerRouter.NativeTracer().Tracer.Hooks
 
 	// Set tx context
 	t.state.SetTxContext(tx.Hash(), len(t.pendingBlock.Messages))

--- a/chain/test_chain.go
+++ b/chain/test_chain.go
@@ -754,7 +754,7 @@ func (t *TestChain) PendingBlockAddTx(message *core.Message, additionalTracers .
 		// If we have more tracers, extend the transaction tracer router's tracers with additional ones
 		extendedTracerRouter = NewTestChainTracerRouter()
 		extendedTracerRouter.AddTracer(t.transactionTracerRouter.NativeTracer())
-		t.transactionTracerRouter.AddTracers(additionalTracers...)
+		extendedTracerRouter.AddTracers(additionalTracers...)
 	} else {
 		extendedTracerRouter = t.transactionTracerRouter
 	}

--- a/chain/test_chain_test.go
+++ b/chain/test_chain_test.go
@@ -260,7 +260,7 @@ func TestChainDynamicDeployments(t *testing.T) {
 						assert.NoError(t, err)
 
 						// Add our transaction to the block
-						err = chain.PendingBlockAddTx(&msg, nil)
+						err = chain.PendingBlockAddTx(&msg)
 						assert.NoError(t, err)
 
 						// Commit the pending block to the chain, so it becomes the new head.
@@ -385,7 +385,7 @@ func TestChainDeploymentWithArgs(t *testing.T) {
 					assert.NoError(t, err)
 
 					// Add our transaction to the block
-					err = chain.PendingBlockAddTx(&msg, nil)
+					err = chain.PendingBlockAddTx(&msg)
 					assert.NoError(t, err)
 
 					// Commit the pending block to the chain, so it becomes the new head.
@@ -494,7 +494,7 @@ func TestChainCloning(t *testing.T) {
 							assert.NoError(t, err)
 
 							// Add our transaction to the block
-							err = chain.PendingBlockAddTx(&msg, nil)
+							err = chain.PendingBlockAddTx(&msg)
 							assert.NoError(t, err)
 
 							// Commit the pending block to the chain, so it becomes the new head.
@@ -588,7 +588,7 @@ func TestChainCallSequenceReplayMatchSimple(t *testing.T) {
 							assert.NoError(t, err)
 
 							// Add our transaction to the block
-							err = chain.PendingBlockAddTx(&msg, nil)
+							err = chain.PendingBlockAddTx(&msg)
 							assert.NoError(t, err)
 
 							// Commit the pending block to the chain, so it becomes the new head.
@@ -627,7 +627,7 @@ func TestChainCallSequenceReplayMatchSimple(t *testing.T) {
 			_, err := recreatedChain.PendingBlockCreate()
 			assert.NoError(t, err)
 			for _, message := range chain.blocks[i].Messages {
-				err = recreatedChain.PendingBlockAddTx(message, nil)
+				err = recreatedChain.PendingBlockAddTx(message)
 				assert.NoError(t, err)
 			}
 			err = recreatedChain.PendingBlockCommit()

--- a/fuzzing/corpus/corpus.go
+++ b/fuzzing/corpus/corpus.go
@@ -210,7 +210,7 @@ func (c *Corpus) initializeSequences(sequenceFiles *corpusDirectory[calls.CallSe
 		}
 
 		// Execute each call sequence, populating runtime data and collecting coverage data along the way.
-		_, err = calls.ExecuteCallSequenceIteratively(testChain, fetchElementFunc, executionCheckFunc, nil)
+		_, err = calls.ExecuteCallSequenceIteratively(testChain, fetchElementFunc, executionCheckFunc)
 
 		// If we failed to replay a sequence and measure coverage due to an unexpected error, report it.
 		if err != nil {

--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -119,6 +119,8 @@ func (t *ExecutionTracer) OnTxStart(vm *tracing.VMContext, tx *coretypes.Transac
 	t.trace = newExecutionTrace(t.contractDefinitions)
 	t.currentCallFrame = nil
 	t.onNextCaptureState = nil
+	t.traceMap = make(map[common.Hash]*ExecutionTrace)
+
 	// Store our evm reference
 	t.evmContext = vm
 }

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -463,7 +463,7 @@ func chainSetupFromCompilations(fuzzer *Fuzzer, testChain *chain.TestChain) (*ex
 				}
 
 				// Add our transaction to the block
-				err = testChain.PendingBlockAddTx(msg.ToCoreMessage(), nil)
+				err = testChain.PendingBlockAddTx(msg.ToCoreMessage())
 				if err != nil {
 					return nil, err
 				}

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -317,7 +317,7 @@ func (fw *FuzzerWorker) testNextCallSequence() (calls.CallSequence, []ShrinkCall
 	}
 
 	// Execute our call sequence.
-	testedCallSequence, err := calls.ExecuteCallSequenceIteratively(fw.chain, fetchElementFunc, executionCheckFunc, nil)
+	testedCallSequence, err := calls.ExecuteCallSequenceIteratively(fw.chain, fetchElementFunc, executionCheckFunc)
 
 	// If we encountered an error, report it.
 	if err != nil {
@@ -383,7 +383,7 @@ func (fw *FuzzerWorker) testShrunkenCallSequence(possibleShrunkSequence calls.Ca
 	}
 
 	// Execute our call sequence.
-	_, err = calls.ExecuteCallSequenceIteratively(fw.chain, fetchElementFunc, executionCheckFunc, nil)
+	_, err = calls.ExecuteCallSequenceIteratively(fw.chain, fetchElementFunc, executionCheckFunc)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Closes #410.

There was a bug when execution tracing a transaction that would override the tracers that were attached to the EVM instance. Thus, the cheatcode tracer was not attached when execution tracing. When something like `prank` was called, the code would be unable to use the cheatcode tracer which would cause a panic. 

The fix required updating the Test Chain APIs to accept any additional tracers that need to be attached before EVM execution. These tracers are appended and do not override the original set.