### PR TITLE
fix: get code from scope to report constructor coverage correctly

### DIFF
--- a/fuzzing/coverage/coverage_tracer.go
+++ b/fuzzing/coverage/coverage_tracer.go
@@ -155,7 +155,9 @@ func (t *CoverageTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tr
 
 	// If there is code we're executing, collect coverage.
 	address := scope.Address()
-	code := t.evmContext.StateDB.GetCode(address)
+	// We can cast OpContext to ScopeContext because that is the type passed to OnOpcode.
+	scopeContext := scope.(*vm.ScopeContext)
+	code := scopeContext.Contract.Code
 	codeSize := len(code)
 	if codeSize > 0 {
 


### PR DESCRIPTION
fixes the issue of the constructor not showing as covered in https://github.com/crytic/echidna/issues/1296. For newly deployed contracts, we can't use the stateDB to get the code as they haven't been entered and will return empty code.