### PR TITLE
fix: do not add seq's with failing receipt status to success corpus

### DIFF
--- a/fuzzing/corpus/corpus_test.go
+++ b/fuzzing/corpus/corpus_test.go
@@ -2,14 +2,15 @@ package corpus
 
 import (
 	"encoding/json"
-	"github.com/crytic/medusa/fuzzing/calls"
-	"github.com/crytic/medusa/utils/testutils"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"math/rand"
 	"path/filepath"
 	"testing"
+
+	"github.com/crytic/medusa/fuzzing/calls"
+	"github.com/crytic/medusa/utils/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 )
 
 // getMockSimpleCorpus creates a mock corpus with numEntries callSequencesByFilePath for testing
@@ -23,7 +24,7 @@ func getMockSimpleCorpus(minSequences int, maxSequences, minBlocks int, maxBlock
 	// Add the requested number of entries.
 	numSequences := minSequences + (rand.Int() % (maxSequences - minSequences))
 	for i := 0; i < numSequences; i++ {
-		err := corpus.addCallSequence(corpus.mutableSequenceFiles, getMockCallSequence(minBlocks+(rand.Int()%(maxBlocks-minBlocks))), true, nil, false)
+		err := corpus.addCallSequence(corpus.successfulSequenceFiles, getMockCallSequence(minBlocks+(rand.Int()%(maxBlocks-minBlocks))), true, nil, false)
 		if err != nil {
 			return nil, err
 		}
@@ -100,9 +101,9 @@ func TestCorpusReadWrite(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Ensure that there are the correct number of call sequence files
-		matches, err := filepath.Glob(filepath.Join(corpus.mutableSequenceFiles.path, "*.json"))
+		matches, err := filepath.Glob(filepath.Join(corpus.successfulSequenceFiles.path, "*.json"))
 		assert.NoError(t, err)
-		assert.EqualValues(t, len(corpus.mutableSequenceFiles.files), len(matches))
+		assert.EqualValues(t, len(corpus.successfulSequenceFiles.files), len(matches))
 
 		// Wipe corpus clean so that you can now read it in from disk
 		corpus, err = NewCorpus("corpus")
@@ -124,7 +125,7 @@ func TestCorpusCallSequenceMarshaling(t *testing.T) {
 	// Run the test in our temporary test directory to avoid artifact pollution.
 	testutils.ExecuteInDirectory(t, t.TempDir(), func() {
 		// For each entry, marshal it and then unmarshal the byte array
-		for _, entryFile := range corpus.mutableSequenceFiles.files {
+		for _, entryFile := range corpus.successfulSequenceFiles.files {
 			// Marshal the entry
 			b, err := json.Marshal(entryFile.data)
 			assert.NoError(t, err)
@@ -139,9 +140,9 @@ func TestCorpusCallSequenceMarshaling(t *testing.T) {
 		}
 
 		// Remove all items
-		for i := 0; i < len(corpus.mutableSequenceFiles.files); {
-			corpus.mutableSequenceFiles.removeFile(corpus.mutableSequenceFiles.files[i].fileName)
+		for i := 0; i < len(corpus.successfulSequenceFiles.files); {
+			corpus.successfulSequenceFiles.removeFile(corpus.successfulSequenceFiles.files[i].fileName)
 		}
-		assert.Empty(t, corpus.mutableSequenceFiles.files)
+		assert.Empty(t, corpus.successfulSequenceFiles.files)
 	})
 }

--- a/fuzzing/coverage/coverage_maps.go
+++ b/fuzzing/coverage/coverage_maps.go
@@ -2,11 +2,12 @@ package coverage
 
 import (
 	"bytes"
+	"sync"
+
 	compilationTypes "github.com/crytic/medusa/compilation/types"
 	"github.com/crytic/medusa/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"sync"
 )
 
 // CoverageMaps represents a data structure used to identify instruction execution coverage of various smart contracts
@@ -158,8 +159,8 @@ func (cm *CoverageMaps) Update(coverageMaps *CoverageMaps) (bool, bool, error) {
 				}
 			} else {
 				mapsByAddress[codeAddress] = coverageMapToMerge
-				successCoverageChanged = coverageMapToMerge.successfulCoverage != nil
-				revertedCoverageChanged = coverageMapToMerge.revertedCoverage != nil
+				successCoverageChanged = coverageMapToMerge.HasSuccessCoverage()
+				revertedCoverageChanged = coverageMapToMerge.HasRevertCoverage()
 			}
 		}
 	}
@@ -258,6 +259,16 @@ func newContractCoverageMap() *ContractCoverageMap {
 		successfulCoverage: &CoverageMapBytecodeData{},
 		revertedCoverage:   &CoverageMapBytecodeData{},
 	}
+}
+
+// HasSuccessCoverage checks if the contract has successful coverage.
+func (cm *ContractCoverageMap) HasSuccessCoverage() bool {
+	return cm.successfulCoverage != nil && cm.successfulCoverage.executedFlags != nil
+}
+
+// HasRevertCoverage checks if the contract has reverted coverage.
+func (cm *ContractCoverageMap) HasRevertCoverage() bool {
+	return cm.revertedCoverage != nil && cm.revertedCoverage.executedFlags != nil
 }
 
 // Equal checks whether the provided ContractCoverageMap contains the same data as the current one.

--- a/fuzzing/testdata/contracts/deployments/predeploy_contract.sol
+++ b/fuzzing/testdata/contracts/deployments/predeploy_contract.sol
@@ -1,6 +1,11 @@
 contract PredeployContract {
+    bool called = false;
+
     function triggerFailure() public {
-        assert(false);
+        if (called) {
+            assert(false);
+        }
+        called = true;
     }
 }
 


### PR DESCRIPTION
The assumption that only success or reverting coverage is broken by patterns like the following. Instead we will use the tx's receipt to decide whether to consider the seq. in mutations. Also, the `executionFlags` that `RevertAll()` sets to `nil` weren't being check, only the existence of coverage maps.

```
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;
interface ITransientStorageTest {
    function x() external view returns (uint);
    
}
contract B {
    function Z() external {
        if (ITransientStorageTest(msg.sender).x() == 0) {
            revert();
        } else {
            return;
        }
        
    }
 }
contract TransientStorageTest {
    uint public x;
    function useTransientStorage(uint256 data) public {
        B b = new B();
        try b.Z() {

        } catch  {
            x++;
        }
        if (x > 2) {
            x++;
        }
    }

}
```