### PR TITLE
docs/interface-renaming

### DIFF
--- a/docs/src/cheatcodes/cheatcodes_overview.md
+++ b/docs/src/cheatcodes/cheatcodes_overview.md
@@ -11,7 +11,7 @@ However, it is important to note that medusa does not support all the cheatcodes
 by Foundry (see below for supported cheatcodes).
 
 ```solidity
-interface StdCheats {
+interface IStdCheats {
     // Set block.timestamp
     function warp(uint256) external;
 


### PR DESCRIPTION
The goal of this pr is to rename `StdCheats` to `IStdCheats` in the [cheatcodes_overview.md](https://github.com/crytic/medusa/blob/master/docs/src/cheatcodes/cheatcodes_overview.md) documentation file.