### PR TITLE
feat: LCOV report

### DIFF
--- a/compilation/platforms/crytic_compile.go
+++ b/compilation/platforms/crytic_compile.go
@@ -204,7 +204,7 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 			}
 
 			// Retrieve the source unit ID
-			sourceUnitId := ast.GetSourceUnitID()
+			sourceUnitId := types.GetSrcMapSourceUnitID(ast.Src)
 			compilation.SourcePathToArtifact[sourcePath] = types.SourceArtifact{
 				// TODO: Our types.AST is not the same as the original AST but we could parse it and avoid using "any"
 				Ast:          source.AST,

--- a/compilation/platforms/solc.go
+++ b/compilation/platforms/solc.go
@@ -145,7 +145,7 @@ func (s *SolcCompilationConfig) Compile() ([]types.Compilation, string, error) {
 				}
 
 				// Get the source unit ID
-				sourceUnitId := ast.GetSourceUnitID()
+				sourceUnitId := types.GetSrcMapSourceUnitID(ast.Src)
 				// Construct our compiled source object
 				compilation.SourcePathToArtifact[sourcePath] = types.SourceArtifact{
 					// TODO our types.AST is not the same as the original AST but we could parse it and avoid using "any"

--- a/compilation/types/ast.go
+++ b/compilation/types/ast.go
@@ -23,10 +23,55 @@ type Node interface {
 	GetNodeType() string
 }
 
+// FunctionDefinition is the function definition node
+type FunctionDefinition struct {
+	// NodeType represents the node type (currently we only evaluate source unit node types)
+	NodeType string `json:"nodeType"`
+	// Src is the source file for this AST
+	Src  string `json:"src"`
+	Name string `json:"name,omitempty"`
+}
+
+func (s FunctionDefinition) GetNodeType() string {
+	return s.NodeType
+}
+
+func (s FunctionDefinition) GetStart() int {
+	// 95:42:0 returns 95
+	re := regexp.MustCompile(`([0-9]*):[0-9]*:[0-9]*`)
+	startCandidates := re.FindStringSubmatch(s.Src)
+
+	if len(startCandidates) == 2 { // FindStringSubmatch includes the whole match as the first element
+		start, err := strconv.Atoi(startCandidates[1])
+		if err == nil {
+			return start
+		}
+	}
+	return -1
+}
+
+func (s FunctionDefinition) GetLength() int {
+	// 95:42:0 returns 42
+	re := regexp.MustCompile(`[0-9]*:([0-9]*):[0-9]*`)
+	endCandidates := re.FindStringSubmatch(s.Src)
+
+	if len(endCandidates) == 2 { // FindStringSubmatch includes the whole match as the first element
+		end, err := strconv.Atoi(endCandidates[1])
+		if err == nil {
+			return end
+		}
+	}
+	return -1
+}
+
 // ContractDefinition is the contract definition node
 type ContractDefinition struct {
-	// NodeType represents the AST node type (note that it will always be a contract definition)
+	// NodeType represents the node type (currently we only evaluate source unit node types)
 	NodeType string `json:"nodeType"`
+	// Nodes is a list of Nodes within the AST
+	Nodes []Node `json:"nodes"`
+	// Src is the source file for this AST
+	Src string `json:"src"`
 	// CanonicalName is the name of the contract definition
 	CanonicalName string `json:"canonicalName,omitempty"`
 	// Kind is a ContractKind that represents what type of contract definition this is (contract, interface, or library)
@@ -36,6 +81,49 @@ type ContractDefinition struct {
 // GetNodeType implements the Node interface and returns the node type for the contract definition
 func (s ContractDefinition) GetNodeType() string {
 	return s.NodeType
+}
+
+func (c *ContractDefinition) UnmarshalJSON(data []byte) error {
+	// Unmarshal the top-level AST into our own representation. Defer the unmarshaling of all the individual nodes until later
+	type Alias ContractDefinition
+	aux := &struct {
+		Nodes []json.RawMessage `json:"nodes"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(c),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Iterate through all the nodes of the contract definition
+	for _, nodeData := range aux.Nodes {
+		// Unmarshal the node data to retrieve the node type
+		var nodeType struct {
+			NodeType string `json:"nodeType"`
+		}
+		if err := json.Unmarshal(nodeData, &nodeType); err != nil {
+			return err
+		}
+
+		// Unmarshal the contents of the node based on the node type
+		switch nodeType.NodeType {
+		case "FunctionDefinition":
+			// If this is a function definition, unmarshal it
+			var functionDefinition FunctionDefinition
+			if err := json.Unmarshal(nodeData, &functionDefinition); err != nil {
+				return err
+			}
+			c.Nodes = append(c.Nodes, functionDefinition)
+		default:
+			continue
+		}
+	}
+
+	return nil
+
 }
 
 // AST is the abstract syntax tree
@@ -62,11 +150,6 @@ func (a *AST) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Check if nodeType is "SourceUnit". Return early otherwise
-	if aux.NodeType != "SourceUnit" {
-		return nil
-	}
-
 	// Iterate through all the nodes of the source unit
 	for _, nodeData := range aux.Nodes {
 		// Unmarshal the node data to retrieve the node type
@@ -78,7 +161,6 @@ func (a *AST) UnmarshalJSON(data []byte) error {
 		}
 
 		// Unmarshal the contents of the node based on the node type
-		var node Node
 		switch nodeType.NodeType {
 		case "ContractDefinition":
 			// If this is a contract definition, unmarshal it
@@ -86,14 +168,21 @@ func (a *AST) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(nodeData, &contractDefinition); err != nil {
 				return err
 			}
-			node = contractDefinition
+			a.Nodes = append(a.Nodes, contractDefinition)
+
+		case "FunctionDefinition":
+			// If this is a function definition, unmarshal it
+			var functionDefinition FunctionDefinition
+			if err := json.Unmarshal(nodeData, &functionDefinition); err != nil {
+				return err
+			}
+			a.Nodes = append(a.Nodes, functionDefinition)
+
 		// TODO: Add cases for other node types as needed
 		default:
 			continue
 		}
 
-		// Append the node
-		a.Nodes = append(a.Nodes, node)
 	}
 
 	return nil

--- a/docs/src/coverage_reports.md
+++ b/docs/src/coverage_reports.md
@@ -2,16 +2,22 @@
 
 ## Generating HTML Report from LCOV
 
-Enable coverage reporting by passing a directory over the CLI (`--corpus-dir`) or by setting the `corpusDirectory` key in the configuration file.
+Enable coverage reporting by setting the `corpusDirectory` key in the configuration file and setting the `coverageReports` key to `["lcov", "html"]`.
 
-````bash
+```json
+{
+  "corpusDirectory": "corpus",
+  "coverageReports": ["lcov", "html"]
+}
+```
 
 ### Install lcov and genhtml
 
 Linux:
+
 ```bash
 apt-get install lcov
-````
+```
 
 MacOS:
 
@@ -23,8 +29,11 @@ brew install lcov
 
 ```bash
 
-genhtml corpus/coverage/lcov.info --output-dir corpus
+genhtml corpus/coverage/lcov.info --output-dir corpus --rc derive_function_end_line=0
 ```
+
+> [!WARNING]  
+> ** The `derive_function_end_line` flag is required to prevent the `genhtml` tool from crashing when processing the Solidity source code. **
 
 Open the `corpus/index.html` file in your browser or follow the steps to use VSCode below.
 

--- a/docs/src/coverage_reports.md
+++ b/docs/src/coverage_reports.md
@@ -1,3 +1,35 @@
 # Coverage Reports
 
-WIP
+## Generating HTML Report from LCOV
+
+Enable coverage reporting by passing a directory over the CLI (`--corpus-dir`) or by setting the `corpusDirectory` key in the configuration file.
+
+````bash
+
+### Install lcov and genhtml
+
+Linux:
+```bash
+apt-get install lcov
+````
+
+MacOS:
+
+```bash
+brew install lcov
+```
+
+### Generate LCOV Report
+
+```bash
+
+genhtml corpus/coverage/lcov.info --output-dir corpus
+```
+
+Open the `corpus/index.html` file in your browser or follow the steps to use VSCode below.
+
+### View Coverage Report in VSCode with Coverage Gutters
+
+Install the [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) extension.
+
+Then, right click in a project file and select `Coverage Gutters: Display Coverage`.

--- a/docs/src/project_configuration/fuzzing_config.md
+++ b/docs/src/project_configuration/fuzzing_config.md
@@ -55,6 +55,13 @@ The fuzzing configuration defines the parameters for the fuzzing campaign.
   can then be re-used/mutated by the fuzzer during the next fuzzing campaign.
 - **Default**: ""
 
+### `coverageReports`
+
+- **Type**: [String] (e.g. `["lcov"]`)
+- **Description**: The coverage reports to generate after the fuzzing campaign has completed. The coverage reports are saved
+  in the `coverage` directory within `corpusDirectory`.
+- **Default**: `["lcov", "html"]`
+
 ### `targetContracts`
 
 - **Type**: [String] (e.g. `[FirstContract, SecondContract, ThirdContract]`)

--- a/docs/src/project_configuration/fuzzing_config.md
+++ b/docs/src/project_configuration/fuzzing_config.md
@@ -55,11 +55,11 @@ The fuzzing configuration defines the parameters for the fuzzing campaign.
   can then be re-used/mutated by the fuzzer during the next fuzzing campaign.
 - **Default**: ""
 
-### `coverageReports`
+### `coverageFormats`
 
 - **Type**: [String] (e.g. `["lcov"]`)
 - **Description**: The coverage reports to generate after the fuzzing campaign has completed. The coverage reports are saved
-  in the `coverage` directory within `corpusDirectory`.
+  in the `coverage` directory within `crytic-export/` or `corpusDirectory` if configured.
 - **Default**: `["lcov", "html"]`
 
 ### `targetContracts`

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -399,7 +399,7 @@ func (p *ProjectConfig) Validate() error {
 	if p.Fuzzing.CoverageReports != nil {
 		for _, report := range p.Fuzzing.CoverageReports {
 			if report != "lcov" && report != "html" {
-				return errors.New(fmt.Sprintf("project configuration must specify only valid coverage reports (lcov, html): %s", report))
+				return fmt.Errorf("project configuration must specify only valid coverage reports (lcov, html): %s", report)
 			}
 		}
 	}

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 
@@ -59,6 +60,9 @@ type FuzzingConfig struct {
 
 	// CoverageEnabled describes whether to use coverage-guided fuzzing
 	CoverageEnabled bool `json:"coverageEnabled"`
+
+	// CoverageReports indicate which reports to generate: "lcov" and "html" are supported.
+	CoverageReports []string `json:"coverageReports"`
 
 	// TargetContracts are the target contracts for fuzz testing
 	TargetContracts []string `json:"targetContracts"`
@@ -388,6 +392,18 @@ func (p *ProjectConfig) Validate() error {
 	for _, addr := range p.Fuzzing.PredeployedContracts {
 		if _, err := utils.HexStringToAddress(addr); err != nil {
 			return errors.New("project configuration must specify only well-formed predeployed contract address(es)")
+		}
+	}
+
+	// The coverage report format must be either "lcov" or "html"
+	if p.Fuzzing.CoverageReports != nil {
+		if p.Fuzzing.CorpusDirectory == "" {
+			return errors.New("project configuration must specify a corpus directory if coverage reports are enabled")
+		}
+		for _, report := range p.Fuzzing.CoverageReports {
+			if report != "lcov" && report != "html" {
+				return errors.New(fmt.Sprintf("project configuration must specify only valid coverage reports (lcov, html): %s", report))
+			}
 		}
 	}
 

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -397,9 +397,6 @@ func (p *ProjectConfig) Validate() error {
 
 	// The coverage report format must be either "lcov" or "html"
 	if p.Fuzzing.CoverageReports != nil {
-		if p.Fuzzing.CorpusDirectory == "" {
-			return errors.New("project configuration must specify a corpus directory if coverage reports are enabled")
-		}
 		for _, report := range p.Fuzzing.CoverageReports {
 			if report != "lcov" && report != "html" {
 				return errors.New(fmt.Sprintf("project configuration must specify only valid coverage reports (lcov, html): %s", report))

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -61,8 +61,8 @@ type FuzzingConfig struct {
 	// CoverageEnabled describes whether to use coverage-guided fuzzing
 	CoverageEnabled bool `json:"coverageEnabled"`
 
-	// CoverageReports indicate which reports to generate: "lcov" and "html" are supported.
-	CoverageReports []string `json:"coverageReports"`
+	// CoverageFormats indicate which reports to generate: "lcov" and "html" are supported.
+	CoverageFormats []string `json:"coverageFormats"`
 
 	// TargetContracts are the target contracts for fuzz testing
 	TargetContracts []string `json:"targetContracts"`
@@ -396,8 +396,8 @@ func (p *ProjectConfig) Validate() error {
 	}
 
 	// The coverage report format must be either "lcov" or "html"
-	if p.Fuzzing.CoverageReports != nil {
-		for _, report := range p.Fuzzing.CoverageReports {
+	if p.Fuzzing.CoverageFormats != nil {
+		for _, report := range p.Fuzzing.CoverageFormats {
 			if report != "lcov" && report != "html" {
 				return fmt.Errorf("project configuration must specify only valid coverage reports (lcov, html): %s", report)
 			}

--- a/fuzzing/config/config_defaults.go
+++ b/fuzzing/config/config_defaults.go
@@ -46,6 +46,7 @@ func GetDefaultProjectConfig(platform string) (*ProjectConfig, error) {
 			ConstructorArgs:         map[string]map[string]any{},
 			CorpusDirectory:         "",
 			CoverageEnabled:         true,
+			CoverageReports:         []string{"html", "lcov	"},
 			SenderAddresses: []string{
 				"0x10000",
 				"0x20000",

--- a/fuzzing/config/config_defaults.go
+++ b/fuzzing/config/config_defaults.go
@@ -46,7 +46,7 @@ func GetDefaultProjectConfig(platform string) (*ProjectConfig, error) {
 			ConstructorArgs:         map[string]map[string]any{},
 			CorpusDirectory:         "",
 			CoverageEnabled:         true,
-			CoverageReports:         []string{"html", "lcov	"},
+			CoverageReports:         []string{"html", "lcov"},
 			SenderAddresses: []string{
 				"0x10000",
 				"0x20000",

--- a/fuzzing/config/config_defaults.go
+++ b/fuzzing/config/config_defaults.go
@@ -46,7 +46,7 @@ func GetDefaultProjectConfig(platform string) (*ProjectConfig, error) {
 			ConstructorArgs:         map[string]map[string]any{},
 			CorpusDirectory:         "",
 			CoverageEnabled:         true,
-			CoverageReports:         []string{"html", "lcov"},
+			CoverageFormats:         []string{"html", "lcov"},
 			SenderAddresses: []string{
 				"0x10000",
 				"0x20000",

--- a/fuzzing/config/gen_fuzzing_config.go
+++ b/fuzzing/config/gen_fuzzing_config.go
@@ -23,6 +23,7 @@ func (f FuzzingConfig) MarshalJSON() ([]byte, error) {
 		CallSequenceLength      int                       `json:"callSequenceLength"`
 		CorpusDirectory         string                    `json:"corpusDirectory"`
 		CoverageEnabled         bool                      `json:"coverageEnabled"`
+		CoverageReports         []string                  `json:"coverageReports"`
 		TargetContracts         []string                  `json:"targetContracts"`
 		PredeployedContracts    map[string]string         `json:"predeployedContracts"`
 		TargetContractsBalances []*hexutil.Big            `json:"targetContractsBalances"`
@@ -45,6 +46,7 @@ func (f FuzzingConfig) MarshalJSON() ([]byte, error) {
 	enc.CallSequenceLength = f.CallSequenceLength
 	enc.CorpusDirectory = f.CorpusDirectory
 	enc.CoverageEnabled = f.CoverageEnabled
+	enc.CoverageReports = f.CoverageReports
 	enc.TargetContracts = f.TargetContracts
 	enc.PredeployedContracts = f.PredeployedContracts
 	if f.TargetContractsBalances != nil {
@@ -76,6 +78,7 @@ func (f *FuzzingConfig) UnmarshalJSON(input []byte) error {
 		CallSequenceLength      *int                      `json:"callSequenceLength"`
 		CorpusDirectory         *string                   `json:"corpusDirectory"`
 		CoverageEnabled         *bool                     `json:"coverageEnabled"`
+		CoverageReports         []string                  `json:"coverageReports"`
 		TargetContracts         []string                  `json:"targetContracts"`
 		PredeployedContracts    map[string]string         `json:"predeployedContracts"`
 		TargetContractsBalances []*hexutil.Big            `json:"targetContractsBalances"`
@@ -116,6 +119,9 @@ func (f *FuzzingConfig) UnmarshalJSON(input []byte) error {
 	}
 	if dec.CoverageEnabled != nil {
 		f.CoverageEnabled = *dec.CoverageEnabled
+	}
+	if dec.CoverageReports != nil {
+		f.CoverageReports = dec.CoverageReports
 	}
 	if dec.TargetContracts != nil {
 		f.TargetContracts = dec.TargetContracts

--- a/fuzzing/config/gen_fuzzing_config.go
+++ b/fuzzing/config/gen_fuzzing_config.go
@@ -23,7 +23,7 @@ func (f FuzzingConfig) MarshalJSON() ([]byte, error) {
 		CallSequenceLength      int                       `json:"callSequenceLength"`
 		CorpusDirectory         string                    `json:"corpusDirectory"`
 		CoverageEnabled         bool                      `json:"coverageEnabled"`
-		CoverageReports         []string                  `json:"coverageReports"`
+		CoverageFormats         []string                  `json:"coverageFormats"`
 		TargetContracts         []string                  `json:"targetContracts"`
 		PredeployedContracts    map[string]string         `json:"predeployedContracts"`
 		TargetContractsBalances []*hexutil.Big            `json:"targetContractsBalances"`
@@ -46,7 +46,7 @@ func (f FuzzingConfig) MarshalJSON() ([]byte, error) {
 	enc.CallSequenceLength = f.CallSequenceLength
 	enc.CorpusDirectory = f.CorpusDirectory
 	enc.CoverageEnabled = f.CoverageEnabled
-	enc.CoverageReports = f.CoverageReports
+	enc.CoverageFormats = f.CoverageFormats
 	enc.TargetContracts = f.TargetContracts
 	enc.PredeployedContracts = f.PredeployedContracts
 	if f.TargetContractsBalances != nil {
@@ -78,7 +78,7 @@ func (f *FuzzingConfig) UnmarshalJSON(input []byte) error {
 		CallSequenceLength      *int                      `json:"callSequenceLength"`
 		CorpusDirectory         *string                   `json:"corpusDirectory"`
 		CoverageEnabled         *bool                     `json:"coverageEnabled"`
-		CoverageReports         []string                  `json:"coverageReports"`
+		CoverageFormats         []string                  `json:"coverageFormats"`
 		TargetContracts         []string                  `json:"targetContracts"`
 		PredeployedContracts    map[string]string         `json:"predeployedContracts"`
 		TargetContractsBalances []*hexutil.Big            `json:"targetContractsBalances"`
@@ -120,8 +120,8 @@ func (f *FuzzingConfig) UnmarshalJSON(input []byte) error {
 	if dec.CoverageEnabled != nil {
 		f.CoverageEnabled = *dec.CoverageEnabled
 	}
-	if dec.CoverageReports != nil {
-		f.CoverageReports = dec.CoverageReports
+	if dec.CoverageFormats != nil {
+		f.CoverageFormats = dec.CoverageFormats
 	}
 	if dec.TargetContracts != nil {
 		f.TargetContracts = dec.TargetContracts

--- a/fuzzing/coverage/report_generation.go
+++ b/fuzzing/coverage/report_generation.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/crytic/medusa/compilation/types"
 	"github.com/crytic/medusa/utils"
 )
 
@@ -19,31 +18,8 @@ var (
 	htmlReportTemplate []byte
 )
 
-// GenerateReports takes a set of CoverageMaps and compilations, and produces a coverage report using them, detailing
-// all source mapped ranges of the source files which were covered or not.
-// Returns an error if one occurred.
-func GenerateReports(compilations []types.Compilation, coverageMaps *CoverageMaps, reportDir string) error {
-	// Perform source analysis.
-	sourceAnalysis, err := AnalyzeSourceCoverage(compilations, coverageMaps)
-	if err != nil {
-		return err
-	}
-
-	if reportDir != "" {
-		// Save the LCOV report.
-		err = saveLCOVReport(sourceAnalysis, reportDir)
-		if err != nil {
-			return err
-		}
-
-		// Save the HTML report.
-		err = saveHTMLReport(sourceAnalysis, reportDir)
-	}
-	return err
-}
-
-// saveHTMLReport takes a previously performed source analysis and generates an HTML coverage report from it.
-func saveHTMLReport(sourceAnalysis *SourceAnalysis, reportDir string) error {
+// WriteHTMLReport takes a previously performed source analysis and generates an HTML coverage report from it.
+func WriteHTMLReport(sourceAnalysis *SourceAnalysis, reportDir string) (string, error) {
 	// Define mappings onto some useful variables/functions.
 	functionMap := template.FuncMap{
 		"timeNow": time.Now,
@@ -85,13 +61,13 @@ func saveHTMLReport(sourceAnalysis *SourceAnalysis, reportDir string) error {
 	// Parse our HTML template
 	tmpl, err := template.New("coverage_report.html").Funcs(functionMap).Parse(string(htmlReportTemplate))
 	if err != nil {
-		return fmt.Errorf("could not export report, failed to parse report template: %v", err)
+		return "", fmt.Errorf("could not export report, failed to parse report template: %v", err)
 	}
 
 	// If the directory doesn't exist, create it.
 	err = utils.MakeDirectory(reportDir)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Create our report file
@@ -99,7 +75,7 @@ func saveHTMLReport(sourceAnalysis *SourceAnalysis, reportDir string) error {
 	file, err := os.Create(htmlReportPath)
 	if err != nil {
 		_ = file.Close()
-		return fmt.Errorf("could not export report, failed to open file for writing: %v", err)
+		return "", fmt.Errorf("could not export report, failed to open file for writing: %v", err)
 	}
 
 	// Execute the template and write it back to file.
@@ -108,26 +84,26 @@ func saveHTMLReport(sourceAnalysis *SourceAnalysis, reportDir string) error {
 	if err == nil {
 		err = fileCloseErr
 	}
-	return err
+	return htmlReportPath, err
 }
 
-// saveLCOVReport takes a previously performed source analysis and generates an LCOV report from it.
-func saveLCOVReport(sourceAnalysis *SourceAnalysis, reportDir string) error {
+// WriteLCOVReport takes a previously performed source analysis and generates an LCOV report from it.
+func WriteLCOVReport(sourceAnalysis *SourceAnalysis, reportDir string) (string, error) {
 	// Generate the LCOV report.
 	lcovReport := sourceAnalysis.GenerateLCOVReport()
 
 	// If the directory doesn't exist, create it.
 	err := utils.MakeDirectory(reportDir)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Write the LCOV report to a file.
 	lcovReportPath := filepath.Join(reportDir, "lcov.info")
 	err = os.WriteFile(lcovReportPath, []byte(lcovReport), 0644)
 	if err != nil {
-		return fmt.Errorf("could not export LCOV report: %v", err)
+		return "", fmt.Errorf("could not export LCOV report: %v", err)
 	}
 
-	return nil
+	return lcovReportPath, nil
 }

--- a/fuzzing/coverage/source_analysis.go
+++ b/fuzzing/coverage/source_analysis.go
@@ -90,24 +90,17 @@ func (s *SourceAnalysis) GenerateLCOVReport() string {
 				return file.CumulativeOffsetByLine[i] > byteStart+length
 			})
 
-			instrumented := 0
 			hit := 0
-			count := 0
 			for i := startLine; i < endLine; i++ {
 				// index iz zero based, line numbers are 1 based
-				if file.Lines[i-1].IsActive {
-					instrumented++
-					if file.Lines[i-1].IsCovered {
-						hit++
-					}
+				if file.Lines[i-1].IsActive && file.Lines[i-1].IsCovered {
+					hit++
 				}
-			}
-			if hit == instrumented {
-				count = 1
+
 			}
 
 			buffer.WriteString(fmt.Sprintf("FN:%d,%s\n", startLine, fn.Name))
-			buffer.WriteString(fmt.Sprintf("FNDA:%d,%s\n", count, fn.Name))
+			buffer.WriteString(fmt.Sprintf("FNDA:%d,%s\n", hit, fn.Name))
 		}
 	}
 

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -409,6 +409,7 @@ func chainSetupFromCompilations(fuzzer *Fuzzer, testChain *chain.TestChain) (*ex
 					fuzzer.config.Fuzzing.TargetContracts = []string{contract.Name()}
 					found = true
 				} else {
+					// TODO list options for the user to choose from
 					return nil, fmt.Errorf("specify target contract(s)")
 				}
 			}
@@ -826,12 +827,13 @@ func (f *Fuzzer) Start() error {
 
 	// Finally, generate our coverage report if we have set a valid corpus directory.
 	if err == nil && f.config.Fuzzing.CorpusDirectory != "" {
-		coverageReportPath := filepath.Join(f.config.Fuzzing.CorpusDirectory, "coverage_report.html")
-		err = coverage.GenerateReport(f.compilations, f.corpus.CoverageMaps(), coverageReportPath)
+		coverageReportPath := filepath.Join(f.config.Fuzzing.CorpusDirectory, "coverage")
+		// TODO don't overwrite the coverage report if it already exists and support toggling to LCOV
+		err = coverage.GenerateReports(f.compilations, f.corpus.CoverageMaps(), coverageReportPath)
 		if err != nil {
 			f.logger.Error("Failed to generate coverage report", err)
 		} else {
-			f.logger.Info("Coverage report saved to file: ", colors.Bold, coverageReportPath, colors.Reset)
+			f.logger.Info("Coverage report(s) saved to: ", colors.Bold, coverageReportPath, colors.Reset)
 		}
 	}
 

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -837,7 +837,7 @@ func (f *Fuzzer) Start() error {
 	f.printExitingResults()
 
 	// Finally, generate our coverage report if we have set a valid corpus directory.
-	if err == nil && len(f.config.Fuzzing.CoverageReports) > 0 {
+	if err == nil && len(f.config.Fuzzing.CoverageFormats) > 0 {
 		// Write to the default directory if we have no corpus directory set.
 		coverageReportDir := filepath.Join("crytic-export", "coverage")
 		if f.config.Fuzzing.CorpusDirectory != "" {
@@ -849,7 +849,7 @@ func (f *Fuzzer) Start() error {
 			f.logger.Error("Failed to analyze source coverage", err)
 		} else {
 			var path string
-			for _, reportType := range f.config.Fuzzing.CoverageReports {
+			for _, reportType := range f.config.Fuzzing.CoverageFormats {
 				switch reportType {
 				case "html":
 					path, err = coverage.WriteHTMLReport(sourceAnalysis, coverageReportDir)

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -837,8 +837,12 @@ func (f *Fuzzer) Start() error {
 	f.printExitingResults()
 
 	// Finally, generate our coverage report if we have set a valid corpus directory.
-	if err == nil && f.config.Fuzzing.CorpusDirectory != "" && len(f.config.Fuzzing.CoverageReports) > 0 {
-		coverageReportDir := filepath.Join(f.config.Fuzzing.CorpusDirectory, "coverage")
+	if err == nil && len(f.config.Fuzzing.CoverageReports) > 0 {
+		// Write to the default directory if we have no corpus directory set.
+		coverageReportDir := filepath.Join("crytic-export", "coverage")
+		if f.config.Fuzzing.CorpusDirectory != "" {
+			coverageReportDir = filepath.Join(f.config.Fuzzing.CorpusDirectory, "coverage")
+		}
 		sourceAnalysis, err := coverage.AnalyzeSourceCoverage(f.compilations, f.corpus.CoverageMaps())
 
 		if err != nil {


### PR DESCRIPTION
closes https://github.com/crytic/medusa/issues/418
closes https://github.com/crytic/medusa/issues/462

The LCOV and HTML reports are now enabled by default and saved to crytic-export even if `corpusDirectory` is "". `coverageFormats` should be set to `[]` to disable them


Future work:
- support receive, fallback, and constructor (`fn.Name == ""` and LCOV needs a function name)