### PR TITLE
snapshot and revertTo bug fix

### DIFF
--- a/chain/standard_cheat_code_contract.go
+++ b/chain/standard_cheat_code_contract.go
@@ -285,18 +285,19 @@ func getStandardCheatCodeContract(tracer *cheatCodeTracer) (*CheatCodeContract, 
 	contract.addMethod(
 		"snapshot", abi.Arguments{}, abi.Arguments{{Type: typeUint256}},
 		func(tracer *cheatCodeTracer, inputs []any) ([]any, *cheatCodeRawReturnData) {
-			snapshotID := tracer.chain.State().Snapshot()
+			snapshotID := tracer.chain.state.Snapshot()
+			snapshotIDBigInt := new(big.Int).SetUint64(uint64(snapshotID))
 
-			return []any{snapshotID}, nil
+			return []any{snapshotIDBigInt}, nil
 		},
 	)
 
-	// revertTo(uint256): Revert the state of the evm to a previous snapshot. Takes the snapshot id to revert to.
+	// revertTo(uint256): Restores the blockchain to a previous state by reverting to a specified snapshot, removing that snapshot and all subsequent ones (e.g.: reverting to id 2 will delete snapshots with ids 2, 3, 4, etc.)
 	contract.addMethod(
 		"revertTo", abi.Arguments{{Type: typeUint256}}, abi.Arguments{{Type: typeBool}},
 		func(tracer *cheatCodeTracer, inputs []any) ([]any, *cheatCodeRawReturnData) {
 			snapshotID := inputs[0].(*big.Int)
-			tracer.chain.State().RevertToSnapshot(int(snapshotID.Int64()))
+			tracer.chain.state.RevertToSnapshotPersisted(int(snapshotID.Int64()), true)
 
 			return []any{true}, nil
 		},

--- a/fuzzing/testdata/contracts/cheat_codes/vm/snapshot_and_revert_to.sol
+++ b/fuzzing/testdata/contracts/cheat_codes/vm/snapshot_and_revert_to.sol
@@ -28,31 +28,59 @@ contract TestContract {
 
         store.slot0 = 10;
         store.slot1 = 20;
-        timestamp = block.timestamp;
-        cheats.deal(address(this), 5 ether);
 
-        // Save state
-        uint256 snapshot = cheats.snapshot();
+        // Create first snapshot
+        uint256 snapshot1 = cheats.snapshot();
 
         // Change state
         store.slot0 = 300;
         store.slot1 = 400;
-        cheats.deal(address(this), 500 ether);
-        cheats.warp(12345);
 
         // Assert that state has been changed
         assert(store.slot0 == 300);
         assert(store.slot1 == 400);
-        assert(address(this).balance == 500 ether);
-        assert(block.timestamp == 12345);
 
-        // Revert to snapshot
-        cheats.revertTo(snapshot);
+        // Create second snapshot
+        uint256 snapshot2 = cheats.snapshot();
 
-        // Ensure state has been reset
+        // Change state again
+        store.slot0 = 250;
+        store.slot1 = 67;
+
+        // Assert that state has been changed
+        assert(store.slot0 == 250);
+        assert(store.slot1 == 67);
+
+        // Create third snapshot
+        uint256 snapshot3 = cheats.snapshot();
+
+        // Change state again
+        store.slot0 = 347;
+        store.slot1 = 3;
+
+        // Assert that state has been changed
+        assert(store.slot0 == 347);
+        assert(store.slot1 == 3);
+
+        // Revert to third snapshot
+        cheats.revertTo(snapshot3);
+
+        // Ensure state has been reset to third snapshot
+        assert(store.slot0 == 250);
+        assert(store.slot1 == 67);
+
+        // Revert to second snapshot
+        cheats.revertTo(snapshot2);
+
+        // Ensure state has been reset to second snapshot
+        assert(store.slot0 == 300);
+        assert(store.slot1 == 400);
+
+        // Revert to first snapshot
+        cheats.revertTo(snapshot1);
+
+        // Ensure state has been reset to original
         assert(store.slot0 == 10);
         assert(store.slot1 == 20);
-        assert(address(this).balance == 5 ether);
-        assert(block.timestamp == timestamp);
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -88,4 +88,4 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/crytic/medusa-geth v0.0.0-20240708141007-2f7f9258289f
+replace github.com/ethereum/go-ethereum => github.com/crytic/medusa-geth v0.0.0-20240822132121-f07822f3908a

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,12 @@ github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c/go.mod h1:geZJ
 github.com/crate-crypto/go-kzg-4844 v1.0.0 h1:TsSgHwrkTKecKJ4kadtHi4b3xHW5dCFUDFnUp1TsawI=
 github.com/crate-crypto/go-kzg-4844 v1.0.0/go.mod h1:1kMhvPgI0Ky3yIa+9lFySEBUBXkYxeOi8ZF1sYioxhc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/crytic/medusa-geth v0.0.0-20240702201853-c1e61697c737 h1:e5Zh/Kx9SDFt9YbHKRfy+YdwjYLKMXcQDe2Rapi6mF8=
+github.com/crytic/medusa-geth v0.0.0-20240702201853-c1e61697c737/go.mod h1:sxkMp7Lgg/hBT6CNmxbfmk3PH+ql1RwmKAl8Ei2tjto=
 github.com/crytic/medusa-geth v0.0.0-20240708141007-2f7f9258289f h1:fxAlt4nFXa2WhoGVXbPezydKLFKx0mDRD4voT/xPcF4=
 github.com/crytic/medusa-geth v0.0.0-20240708141007-2f7f9258289f/go.mod h1:hglUZo/5pVIYXNyYjWzsAUDpT/zI+WbWo/Nih7ot+G0=
+github.com/crytic/medusa-geth v0.0.0-20240822132121-f07822f3908a h1:QZJ6WiB5zm2yilBHS9r/LocUtQIWgY6uS8rs4re0K04=
+github.com/crytic/medusa-geth v0.0.0-20240822132121-f07822f3908a/go.mod h1:ajGCVsk6ctffGwe9TSDQqj4HIUUQ1WdUit5tWFNl8Tw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
closes issue #373, [fix](https://github.com/crytic/medusa-geth/commit/f07822f3908a830973d0f6e1424822e2533cd997) applied to medusa-geth. The snapshot and revertTo cheatcodes now use the updated function.
