### PR TITLE
fix: check that receipt is non-nil in `OnTxEnd` hook

### DIFF
--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -1,6 +1,7 @@
 package executiontracer
 
 import (
+	"github.com/crytic/medusa/logging"
 	"math/big"
 
 	"github.com/crytic/medusa/chain"
@@ -110,6 +111,9 @@ func (t *ExecutionTracer) GetTrace(txHash common.Hash) *ExecutionTrace {
 
 // OnTxEnd is called upon the end of transaction execution, as defined by tracers.Tracer.
 func (t *ExecutionTracer) OnTxEnd(receipt *coretypes.Receipt, err error) {
+	if err != nil {
+		logging.GlobalLogger.Panic("transaction failed to execute", err)
+	}
 	t.traceMap[receipt.TxHash] = t.trace
 }
 

--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -1,7 +1,6 @@
 package executiontracer
 
 import (
-	"github.com/crytic/medusa/logging"
 	"math/big"
 
 	"github.com/crytic/medusa/chain"
@@ -111,8 +110,11 @@ func (t *ExecutionTracer) GetTrace(txHash common.Hash) *ExecutionTrace {
 
 // OnTxEnd is called upon the end of transaction execution, as defined by tracers.Tracer.
 func (t *ExecutionTracer) OnTxEnd(receipt *coretypes.Receipt, err error) {
-	if err != nil {
-		logging.GlobalLogger.Panic("transaction failed to execute", err)
+	// We avoid storing the trace for this transaction. An error should realistically only occur if we hit a block gas
+	// limit error. In this case, the transaction will be retried in the next block and we can retrieve the trace at
+	// that time.
+	if err != nil || receipt == nil {
+		return
 	}
 	t.traceMap[receipt.TxHash] = t.trace
 }


### PR DESCRIPTION
We used to store the execution trace without checking the error or whether the receipt was nil in the `OnTxEnd` hook. This seemed fine initially but it is possible that if the block's gas limit is reached, the receipt will be nil and error non-nil because the txn could not be fit into the block.

This PR changes the hook such that the trace is not stored if the receipt is nil or error is non-nil. The reasoning for this is that medusa will retry the failing txn in the next block and at that time we should be able to get the trace.