### PR TITLE
fix: incorrect target contract balance when used with predeploys

### DIFF
--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -419,10 +419,14 @@ func chainSetupFromCompilations(fuzzer *Fuzzer, testChain *chain.TestChain) (*ex
 	// Ordering is important here (predeploys _then_ targets) so that you can have the same contract in both lists
 	// while still being able to use the contract address overrides
 	contractsToDeploy := make([]string, 0)
+	balances := make([]*big.Int, 0)
 	for contractName := range fuzzer.config.Fuzzing.PredeployedContracts {
 		contractsToDeploy = append(contractsToDeploy, contractName)
+		// Preserve index of target contract balances
+		balances = append(balances, big.NewInt(0))
 	}
 	contractsToDeploy = append(contractsToDeploy, fuzzer.config.Fuzzing.TargetContracts...)
+	balances = append(balances, fuzzer.config.Fuzzing.TargetContractsBalances...)
 
 	deployedContractAddr := make(map[string]common.Address)
 	// Loop for all contracts to deploy
@@ -460,8 +464,8 @@ func chainSetupFromCompilations(fuzzer *Fuzzer, testChain *chain.TestChain) (*ex
 
 				// If our project config has a non-zero balance for this target contract, retrieve it
 				contractBalance := big.NewInt(0)
-				if len(fuzzer.config.Fuzzing.TargetContractsBalances) > i {
-					contractBalance = new(big.Int).Set(fuzzer.config.Fuzzing.TargetContractsBalances[i])
+				if len(balances) > i {
+					contractBalance = new(big.Int).Set(balances[i])
 				}
 
 				// Create a message to represent our contract deployment (we let deployments consume the whole block

--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -403,6 +403,7 @@ func TestDeploymentsWithPredeploy(t *testing.T) {
 		filePath: "testdata/contracts/deployments/predeploy_contract.sol",
 		configUpdates: func(config *config.ProjectConfig) {
 			config.Fuzzing.TargetContracts = []string{"TestContract"}
+			config.Fuzzing.TargetContractsBalances = []*big.Int{big.NewInt(1)}
 			config.Fuzzing.TestLimit = 1000 // this test should expose a failure immediately
 			config.Fuzzing.Testing.PropertyTesting.Enabled = false
 			config.Fuzzing.Testing.OptimizationTesting.Enabled = false

--- a/fuzzing/testdata/contracts/deployments/predeploy_contract.sol
+++ b/fuzzing/testdata/contracts/deployments/predeploy_contract.sol
@@ -7,6 +7,8 @@ contract PredeployContract {
 contract TestContract {
     PredeployContract predeploy = PredeployContract(address(0x1234));
 
+    constructor() payable {}
+    
     function testPredeploy() public {
         predeploy.triggerFailure();
     }


### PR DESCRIPTION
Predeploys with non-payable constructors were failing when targetContractBalances was used bc the code relies on the index and it was changed by appending the predeploys. The predeploy unit test was updated as a regression test.