### PR TITLE
Update x86 macOS runner to `macos-13`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: [lint, test]
     strategy:
       matrix:
-        environment: [ubuntu-latest, macos-12, macos-14, windows-latest]
+        environment: [ubuntu-latest, macos-13, macos-14, windows-latest]
     permissions:
       contents: read
       id-token: write
@@ -165,7 +165,7 @@ jobs:
   test:
     strategy:
       matrix:
-        environment: [ubuntu-latest, macos-12, macos-14, windows-latest]
+        environment: [ubuntu-latest, macos-13, macos-14, windows-latest]
 
     runs-on: ${{ matrix.environment }}
     timeout-minutes: 20


### PR DESCRIPTION
The `macos-12` x86 runner will be retired by early December:

    We are beginning the deprecation process for the macOS 12 runner image,
    which allows us to balance our fleet capacity ahead of our upcoming macOS
    15 launch. This image will be fully retired by the December 3rd, 2024. We
    recommend updating workflows to use `macos-14`, `macos-13`, or
    `macos-latest`.

    -- https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/