### PR TITLE
Add exploration mode flag

### DIFF
--- a/cmd/fuzz_flags.go
+++ b/cmd/fuzz_flags.go
@@ -63,6 +63,9 @@ func addFuzzFlags() error {
 	// Logging color
 	fuzzCmd.Flags().Bool("no-color", false, "disabled colored terminal output")
 
+	// Exploration mode
+	fuzzCmd.Flags().Bool("explore", false, "enables exploration mode")
+
 	return nil
 }
 
@@ -161,6 +164,21 @@ func updateProjectConfigWithFuzzFlags(cmd *cobra.Command, projectConfig *config.
 		projectConfig.Logging.NoColor, err = cmd.Flags().GetBool("no-color")
 		if err != nil {
 			return err
+		}
+	}
+
+	// Update configuration to exploration mode
+	if cmd.Flags().Changed("explore") {
+		exploreBool, err := cmd.Flags().GetBool("explore")
+		if err != nil {
+			return err
+		}
+		if exploreBool {
+			projectConfig.Fuzzing.Testing.StopOnFailedTest = false
+			projectConfig.Fuzzing.Testing.StopOnNoTests = false
+			projectConfig.Fuzzing.Testing.AssertionTesting.Enabled = false
+			projectConfig.Fuzzing.Testing.PropertyTesting.Enabled = false
+			projectConfig.Fuzzing.Testing.OptimizationTesting.Enabled = false
 		}
 	}
 	return nil

--- a/docs/src/cli/fuzz.md
+++ b/docs/src/cli/fuzz.md
@@ -129,3 +129,12 @@ The `--no-color` flag disables colored console output (equivalent to
 # Disable colored output
 medusa fuzz --no-color
 ```
+
+### `--explore`
+
+The `--explore` flag enables exploration mode. This sets the [`StopOnFailedTest`](../project_configuration/testing_config.md#stoponfailedtest) and [`StopOnNoTests`](../project_configuration/testing_config.md#stoponnotests) fields to `false` and turns off assertion, property, and optimization testing.
+
+```shell
+# Enable exploration mode
+medusa fuzz --explore
+```


### PR DESCRIPTION
Adds an `--explore` flag that overrides the following config:

- `StopOnFailedTest`: `false`
- `StopOnNoTests`: `false`
- `AssertionTesting.Enabled`: `false`
- `PropertyTesting.Enabled`: `false`
- `OptimizationTesting.Enabled`: `false`

This allows Medusa to imitate the Echidna exploration mode behavior