### PR TITLE
Fix execution tracing during failed contract deployments

### DIFF
--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -533,9 +533,9 @@ func chainSetupFromCompilations(fuzzer *Fuzzer, testChain *chain.TestChain) (*ex
 						Block:            block,
 						TransactionIndex: len(block.Messages) - 1,
 					}
-					// Revert to genesis and re-run the failed contract deployment tx.
+					// Revert to one block before and re-run the failed contract deployment tx.
 					// We should be able to attach an execution trace; however, if it fails, we provide the ExecutionResult at a minimum.
-					err = testChain.RevertToBlockNumber(0)
+					err = testChain.RevertToBlockNumber(block.Header.Number.Uint64() - 1)
 					if err != nil {
 						return nil, fmt.Errorf("failed to reset to genesis block: %v", err)
 					} else {


### PR DESCRIPTION
There was a minor bug during the execution tracing of failed contract deployments. 

We were reverting back to genesis before beginning execution tracing of a failed contract deployment. However, this won't work since we should just revert one block back and reapply the call sequence element. Otherwise, the state of the blockchain is out of sync with the nonce of the sender.