### PR TITLE
Adds support for label cheatcode

### DIFF
--- a/chain/cheat_code_tracer.go
+++ b/chain/cheat_code_tracer.go
@@ -225,6 +225,10 @@ func (t *cheatCodeTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope t
 // tracer is used during transaction execution (block creation), the results can later be queried from the block.
 // This method will only be called on the added tracer if it implements the extended TestChainTracer interface.
 func (t *cheatCodeTracer) CaptureTxEndSetAdditionalResults(results *types.MessageResults) {
+
+	// Add the address label mappings
+	results.AdditionalResults["AddressToLabel"] = t.chain.AddressToLabel
+
 	// Add our revert operations we collected for this transaction.
 	results.OnRevertHookFuncs = append(results.OnRevertHookFuncs, t.results.onChainRevertHooks...)
 }

--- a/chain/standard_cheat_code_contract.go
+++ b/chain/standard_cheat_code_contract.go
@@ -168,6 +168,17 @@ func getStandardCheatCodeContract(tracer *cheatCodeTracer) (*CheatCodeContract, 
 		},
 	)
 
+	// Label: Sets a label for an address.
+	contract.addMethod(
+		"label", abi.Arguments{{Type: typeAddress}, {Type: typeString}}, abi.Arguments{},
+		func(tracer *cheatCodeTracer, inputs []any) ([]any, *cheatCodeRawReturnData) {
+			addr := inputs[0].(common.Address)
+			lbl := inputs[1].(string)
+			tracer.chain.AddressToLabel[addr] = lbl
+			return nil, nil
+		},
+	)
+
 	// Load: Loads a storage slot value from a given account.
 	contract.addMethod(
 		"load", abi.Arguments{{Type: typeAddress}, {Type: typeBytes32}}, abi.Arguments{{Type: typeBytes32}},

--- a/chain/test_chain.go
+++ b/chain/test_chain.go
@@ -75,6 +75,9 @@ type TestChain struct {
 	// This is constructed over the kvstore.
 	db ethdb.Database
 
+	// AddressToLabel maps an address to its label if one exists
+	AddressToLabel map[common.Address]string
+
 	// callTracerRouter forwards tracers.Tracer and TestChainTracer calls to any instances added to it. This
 	// router is used for non-state changing calls.
 	callTracerRouter *TestChainTracerRouter
@@ -156,6 +159,8 @@ func NewTestChain(genesisAlloc types.GenesisAlloc, testChainConfig *config.TestC
 			vmConfigExtensions.AdditionalPrecompiles[cheatContract.address] = cheatContract
 		}
 	}
+	// Initialize address to label mapping
+	AddressToLabel := make(map[common.Address]string)
 
 	// Create an in-memory database
 	db := rawdb.NewMemoryDatabase()
@@ -188,6 +193,7 @@ func NewTestChain(genesisAlloc types.GenesisAlloc, testChainConfig *config.TestC
 		db:                      db,
 		state:                   nil,
 		stateDatabase:           stateDatabase,
+		AddressToLabel:          AddressToLabel,
 		transactionTracerRouter: transactionTracerRouter,
 		callTracerRouter:        callTracerRouter,
 		testChainConfig:         testChainConfig,

--- a/fuzzing/calls/call_sequence.go
+++ b/fuzzing/calls/call_sequence.go
@@ -46,12 +46,18 @@ func (cs CallSequence) Log() *logging.LogBuffer {
 
 	// Construct the buffer for each call made in the sequence
 	for i := 0; i < len(cs); i++ {
+		addressToLabel, ok := cs[i].ChainReference.MessageResults().AdditionalResults["AddressToLabel"].(map[common.Address]string)
+
 		// Add the string representing the call
-		buffer.Append(fmt.Sprintf("%d) %s\n", i+1, cs[i].String()))
+		buffer.Append(utils.ResolveAddressToLabelFromString(fmt.Sprintf("%d) %s\n", i+1, cs[i].String()), addressToLabel))
+
+		if !ok {
+			panic("AdditionalResults[\"AddressToLabel\"] is not of type map[common.Address]string")
+		}
 
 		// If we have an execution trace attached, print information about it.
 		if cs[i].ExecutionTrace != nil {
-			buffer.Append(cs[i].ExecutionTrace.Log().Elements()...)
+			buffer.Append(utils.ResolveAddressToLabelFromElements(cs[i].ExecutionTrace.Log().Elements(), addressToLabel)...)
 			buffer.Append("\n")
 		}
 	}
@@ -286,7 +292,7 @@ func (cse *CallSequenceElement) String() string {
 		cse.Call.GasLimit,
 		cse.Call.GasPrice.String(),
 		cse.Call.Value.String(),
-		utils.TrimLeadingZeroesFromAddress(cse.Call.From.String()),
+		cse.Call.From.String(),
 	)
 }
 

--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -13,7 +13,6 @@ import (
 	"github.com/crytic/medusa/fuzzing/valuegeneration"
 	"github.com/crytic/medusa/logging"
 	"github.com/crytic/medusa/logging/colors"
-	"github.com/crytic/medusa/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -142,19 +141,19 @@ func (t *ExecutionTrace) generateCallFrameEnterElements(callFrame *CallFrame) ([
 	var callInfo string
 	if callFrame.IsProxyCall() {
 		if callFrame.ExecutedCode {
-			callInfo = fmt.Sprintf("%v -> %v.%v(%v) (addr=%v, code=%v, value=%v, sender=%v)", proxyContractName, codeContractName, methodName, *inputArgumentsDisplayText, utils.TrimLeadingZeroesFromAddress(callFrame.ToAddress.String()), utils.TrimLeadingZeroesFromAddress(callFrame.CodeAddress.String()), callFrame.CallValue, utils.TrimLeadingZeroesFromAddress(callFrame.SenderAddress.String()))
+			callInfo = fmt.Sprintf("%v -> %v.%v(%v) (addr=%v, code=%v, value=%v, sender=%v)", proxyContractName, codeContractName, methodName, *inputArgumentsDisplayText, callFrame.ToAddress.String(), callFrame.CodeAddress.String(), callFrame.CallValue, callFrame.SenderAddress.String())
 		} else {
-			callInfo = fmt.Sprintf("(addr=%v, value=%v, sender=%v)", utils.TrimLeadingZeroesFromAddress(callFrame.ToAddress.String()), callFrame.CallValue, utils.TrimLeadingZeroesFromAddress(callFrame.SenderAddress.String()))
+			callInfo = fmt.Sprintf("(addr=%v, value=%v, sender=%v)", callFrame.ToAddress.String(), callFrame.CallValue, callFrame.SenderAddress.String())
 		}
 	} else {
 		if callFrame.ExecutedCode {
 			if callFrame.ToAddress == chain.ConsoleLogContractAddress {
 				callInfo = fmt.Sprintf("%v.%v(%v)", codeContractName, methodName, *inputArgumentsDisplayText)
 			} else {
-				callInfo = fmt.Sprintf("%v.%v(%v) (addr=%v, value=%v, sender=%v)", codeContractName, methodName, *inputArgumentsDisplayText, utils.TrimLeadingZeroesFromAddress(callFrame.ToAddress.String()), callFrame.CallValue, utils.TrimLeadingZeroesFromAddress(callFrame.SenderAddress.String()))
+				callInfo = fmt.Sprintf("%v.%v(%v) (addr=%v, value=%v, sender=%v)", codeContractName, methodName, *inputArgumentsDisplayText, callFrame.ToAddress.String(), callFrame.CallValue, callFrame.SenderAddress.String())
 			}
 		} else {
-			callInfo = fmt.Sprintf("(addr=%v, value=%v, sender=%v)", utils.TrimLeadingZeroesFromAddress(callFrame.ToAddress.String()), callFrame.CallValue, utils.TrimLeadingZeroesFromAddress(callFrame.SenderAddress.String()))
+			callInfo = fmt.Sprintf("(addr=%v, value=%v, sender=%v)", callFrame.ToAddress.String(), callFrame.CallValue, callFrame.SenderAddress.String())
 		}
 	}
 

--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -276,6 +276,7 @@ func TestCheatCodes(t *testing.T) {
 		"testdata/contracts/cheat_codes/vm/roll.sol",
 		"testdata/contracts/cheat_codes/vm/store_load.sol",
 		"testdata/contracts/cheat_codes/vm/warp.sol",
+		"testdata/contracts/cheat_codes/vm/label.sol",
 	}
 
 	// FFI test will fail on Windows because "echo" is a shell command, not a system command, so we diverge these

--- a/fuzzing/testdata/contracts/cheat_codes/vm/label.sol
+++ b/fuzzing/testdata/contracts/cheat_codes/vm/label.sol
@@ -1,0 +1,25 @@
+// This test ensures that label can be set for an address
+interface CheatCodes {
+    function label(address, string memory) external;
+}
+
+contract LabelContract {
+    function testLabel() public {
+        assert(false);
+    }
+}
+
+contract TestContract {
+
+    function test() public {
+        // Obtain our cheat code contract reference.
+        CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+        // Create a contract
+        LabelContract alice = new LabelContract();
+
+        // set label and verify.
+        cheats.label(address(alice), "Alice");
+        alice.testLabel();
+    }
+}

--- a/utils/address_utils.go
+++ b/utils/address_utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"encoding/hex"
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -72,11 +71,11 @@ func ResolveAddressToLabelFromString(str string, addressToLabel map[common.Addre
 	processedString := addressRegex.ReplaceAllStringFunc(str, func(match string) string {
 		address := common.HexToAddress(match) // Convert the match to an Ethereum address
 		if label, exists := addressToLabel[address]; exists {
-			fmt.Printf("Replacing address %s with label %s in element: %s\n", match, label, str)
+			//fmt.Printf("Replacing address %s with label: %s\n", match, label)
 			return label // Replace address with label
 		}
 		trimmedAddress := TrimLeadingZeroesFromAddress(match)
-		fmt.Printf("Address %s does not have a label, trimming leading zeroes to: %s\n", match, trimmedAddress)
+		//fmt.Printf("Address %s does not have a label, trimming leading zeroes to: %s\n", match, trimmedAddress)
 		return trimmedAddress // Keep the address unchanged if no label is found
 	})
 


### PR DESCRIPTION
This PR adds support for label cheat code and closes issue #481 

Specifically, the changes involve the following files:

1. `chain/cheat_code_tracer.go`
2. `chain/standard_cheat_code_contract.go`
3. `chain/test_chain.go`
4. `fuzzing/calls/call_sequence.go`
5. `fuzzing/executiontracer/execution_trace.go`
6. `utils/address_utils.go`
7. `fuzzing/fuzzer_test.go`
8. `fuzzing/testdata/contracts/cheat_codes/vm/label.sol`