### PR TITLE
WIP: Additional HTML report improvements

### DIFF
--- a/fuzzing/coverage/report_template.gohtml
+++ b/fuzzing/coverage/report_template.gohtml
@@ -189,6 +189,14 @@
     <hr />
     <!-- Create a vertically split panel for our file explorer / coverage view -->
     <div class="split-panel" id="file-split-panel">
+        <!-- File explorer tree -->
+        <div id="file-tree-panel">
+            <ul id="file-tree"></ul>
+        </div>
+
+        <!-- Panel splitter -->
+        <div id="split-panel-resizer"></div>
+
         <!-- Main panel (coverage) -->
         <div id="main-view-panel">
             <!-- Individual file coverage -->


### PR DESCRIPTION
Closes #325 

This PR should cover the additional TODOS that were left over from #302:

> Expand/collapse all is OK, but it seems like we need better navigatability. Outstanding tasks are:
> 
> Add a file explorer on the left (similar to GitHub's split pane view for changed files. Needs support to click + jump to a file (should auto expand).
> Add some kind of headings so when you click a file in the explorer, it adds the heading to the page URL (so you can reference it later).
> Add auto-expand to the panels when a selection is made within them. Specifically, if you search for a word like "function" with all source files collapsed, it will show you results but not bring you to them, because the collapsible containers do not expand.

It should also support any additional features requested in #325.