### PR TITLE
Fix traceAll bug

### DIFF
--- a/chain/cheat_code_tracer.go
+++ b/chain/cheat_code_tracer.go
@@ -227,4 +227,6 @@ func (t *cheatCodeTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope t
 func (t *cheatCodeTracer) CaptureTxEndSetAdditionalResults(results *types.MessageResults) {
 	// Add our revert operations we collected for this transaction.
 	results.OnRevertHookFuncs = append(results.OnRevertHookFuncs, t.results.onChainRevertHooks...)
+	// Add the labels so that each transaction has access to it.
+	results.AdditionalResults[labelsKey] = t.chain.Labels
 }

--- a/chain/standard_cheat_code_contract.go
+++ b/chain/standard_cheat_code_contract.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
+	"github.com/crytic/medusa/chain/types"
 	"math/big"
 	"os/exec"
 	"strconv"
@@ -23,6 +24,23 @@ var StandardCheatcodeContractAddress = common.HexToAddress("0x7109709ECfa91a8062
 
 // MaxUint64 holds the max value an uint64 can take
 var _, MaxUint64 = utils.GetIntegerConstraints(false, 64)
+
+// labelsKey describes the key to use when attempting to store and retrieve the chain's labels
+const labelsKey = "Labels"
+
+// GetLabels will return the labels attached to the transaction's messages results. Thus, every call sequence
+// element will have access to all the labels that have been created until that point in time.
+func GetLabels(messageResults *types.MessageResults) map[common.Address]string {
+	// Try to obtain the results the tracer should've stored.
+	if genericResult, ok := messageResults.AdditionalResults[labelsKey]; ok {
+		if castedResult, ok := genericResult.(map[common.Address]string); ok {
+			return castedResult
+		}
+	}
+
+	// If we could not obtain them, return nil.
+	return nil
+}
 
 // getStandardCheatCodeContract obtains a CheatCodeContract which implements common cheat codes.
 // Returns the precompiled contract, or an error if one occurs.

--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -33,7 +33,7 @@ type ExecutionTrace struct {
 	contractDefinitions contracts.Contracts
 
 	// labels is a mapping that maps an address to its string representation for cleaner execution traces
-	Labels map[common.Address]string
+	labels map[common.Address]string
 }
 
 // newExecutionTrace creates and returns a new ExecutionTrace, to be used by the ExecutionTracer.
@@ -41,7 +41,7 @@ func newExecutionTrace(contracts contracts.Contracts, labels map[common.Address]
 	return &ExecutionTrace{
 		TopLevelCallFrame:   nil,
 		contractDefinitions: contracts,
-		Labels:              labels,
+		labels:              labels,
 	}
 }
 
@@ -78,14 +78,14 @@ func (t *ExecutionTrace) generateCallFrameEnterElements(callFrame *CallFrame) ([
 	if callFrame.ToContractAbi != nil {
 		// Check to see if there is a label for the proxy address
 		proxyContractName = callFrame.ToContractName
-		if label, ok := t.Labels[callFrame.ToAddress]; ok {
+		if label, ok := t.labels[callFrame.ToAddress]; ok {
 			proxyContractName = label
 		}
 	}
 	if callFrame.CodeContractAbi != nil {
 		// Check to see if there is a label for the code address
 		codeContractName = callFrame.CodeContractName
-		if label, ok := t.Labels[callFrame.CodeAddress]; ok {
+		if label, ok := t.labels[callFrame.CodeAddress]; ok {
 			codeContractName = label
 		}
 		if callFrame.IsContractCreation() {
@@ -117,7 +117,7 @@ func (t *ExecutionTrace) generateCallFrameEnterElements(callFrame *CallFrame) ([
 		inputValues, err := method.Inputs.Unpack(abiDataInputBuffer)
 		if err == nil {
 			// Encode the ABI arguments into strings and provide the label overrides
-			encodedInputString, err := valuegeneration.EncodeABIArgumentsToString(method.Inputs, inputValues, t.Labels)
+			encodedInputString, err := valuegeneration.EncodeABIArgumentsToString(method.Inputs, inputValues, t.labels)
 			if err == nil {
 				inputArgumentsDisplayText = &encodedInputString
 			}
@@ -152,9 +152,9 @@ func (t *ExecutionTrace) generateCallFrameEnterElements(callFrame *CallFrame) ([
 	}
 
 	// Handle all label overrides
-	toAddress := utils.AttachLabelToAddress(callFrame.ToAddress, t.Labels[callFrame.ToAddress])
-	senderAddress := utils.AttachLabelToAddress(callFrame.SenderAddress, t.Labels[callFrame.SenderAddress])
-	codeAddress := utils.AttachLabelToAddress(callFrame.CodeAddress, t.Labels[callFrame.CodeAddress])
+	toAddress := utils.AttachLabelToAddress(callFrame.ToAddress, t.labels[callFrame.ToAddress])
+	senderAddress := utils.AttachLabelToAddress(callFrame.SenderAddress, t.labels[callFrame.SenderAddress])
+	codeAddress := utils.AttachLabelToAddress(callFrame.CodeAddress, t.labels[callFrame.CodeAddress])
 
 	// Generate the message we wish to output finally, using all these display string components.
 	// If we executed code, attach additional context such as the contract name, method, etc.
@@ -208,7 +208,7 @@ func (t *ExecutionTrace) generateCallFrameExitElements(callFrame *CallFrame) []a
 		if callFrame.ReturnError == nil {
 			outputValues, err := method.Outputs.Unpack(callFrame.ReturnData)
 			if err == nil {
-				encodedOutputString, err := valuegeneration.EncodeABIArgumentsToString(method.Outputs, outputValues, t.Labels)
+				encodedOutputString, err := valuegeneration.EncodeABIArgumentsToString(method.Outputs, outputValues, t.labels)
 				if err == nil {
 					outputArgumentsDisplayText = &encodedOutputString
 				}
@@ -251,7 +251,7 @@ func (t *ExecutionTrace) generateCallFrameExitElements(callFrame *CallFrame) []a
 	// Try to unpack a custom Solidity error from the return values.
 	matchedCustomError, unpackedCustomErrorArgs := abiutils.GetSolidityCustomRevertError(callFrame.CodeContractAbi, callFrame.ReturnError, callFrame.ReturnData)
 	if matchedCustomError != nil {
-		customErrorArgsDisplayText, err := valuegeneration.EncodeABIArgumentsToString(matchedCustomError.Inputs, unpackedCustomErrorArgs, t.Labels)
+		customErrorArgsDisplayText, err := valuegeneration.EncodeABIArgumentsToString(matchedCustomError.Inputs, unpackedCustomErrorArgs, t.labels)
 		if err == nil {
 			elements = append(elements, colors.RedBold, fmt.Sprintf("[revert (error: %v(%v))]", matchedCustomError.Name, customErrorArgsDisplayText), colors.Reset, "\n")
 			return elements
@@ -295,7 +295,7 @@ func (t *ExecutionTrace) generateEventEmittedElements(callFrame *CallFrame, even
 	// If we resolved an event definition and unpacked data.
 	if event != nil {
 		// Format the values as a comma-separated string
-		encodedEventValuesString, err := valuegeneration.EncodeABIArgumentsToString(event.Inputs, eventInputValues, t.Labels)
+		encodedEventValuesString, err := valuegeneration.EncodeABIArgumentsToString(event.Inputs, eventInputValues, t.labels)
 		if err == nil {
 			// Format our event display text finally, with the event name.
 			temp := fmt.Sprintf("%v(%v)", event.Name, encodedEventValuesString)

--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -128,7 +128,6 @@ func (t *ExecutionTracer) OnTxStart(vm *tracing.VMContext, tx *coretypes.Transac
 	t.trace = newExecutionTrace(t.contractDefinitions, t.testChain.Labels)
 	t.currentCallFrame = nil
 	t.onNextCaptureState = nil
-	t.traceMap = make(map[common.Hash]*ExecutionTrace)
 
 	// Store our evm reference
 	t.evmContext = vm

--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -2,11 +2,12 @@ package fuzzing
 
 import (
 	"encoding/hex"
-	"github.com/crytic/medusa/utils"
 	"math/big"
 	"math/rand"
 	"reflect"
 	"testing"
+
+	"github.com/crytic/medusa/utils"
 
 	"github.com/crytic/medusa/chain"
 	"github.com/crytic/medusa/events"


### PR DESCRIPTION
We kept re-creating the trace Map on the execution of each call sequence element. Thus, we weren't storing the traces of all the elements in a call sequence and so `traceAll` wasn't working.

We also now use the labels created by `vm.label` to make the call sequence string look nicer.