### PR TITLE
fix: return nil instead of error directly

### DIFF
--- a/chain/vendored/apply_transaction.go
+++ b/chain/vendored/apply_transaction.go
@@ -99,5 +99,5 @@ func EVMApplyTransaction(msg *Message, config *params.ChainConfig, testChainConf
 	receipt.BlockHash = blockHash
 	receipt.BlockNumber = blockNumber
 	receipt.TransactionIndex = uint(statedb.TxIndex())
-	return receipt, result, err
+	return receipt, result, nil
 }


### PR DESCRIPTION
Since we have already checked err before and returned when err != nil, err must be nil here. 