### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/chain/test_chain.go
+++ b/chain/test_chain.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 
 	"github.com/crytic/medusa/chain/state"
@@ -14,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/ethereum/go-ethereum/triedb/hashdb"
 	"github.com/holiman/uint256"
-	"golang.org/x/exp/maps"
 
 	"github.com/crytic/medusa/chain/types"
 	"github.com/crytic/medusa/chain/vendored"

--- a/chain/test_chain_tracer.go
+++ b/chain/test_chain_tracer.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"math/big"
+	"slices"
 
 	"github.com/crytic/medusa/chain/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -9,7 +10,6 @@ import (
 	coretypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
-	"golang.org/x/exp/slices"
 )
 
 // TestChainTracer is an extended tracers.Tracer which can be used with a TestChain to store any captured

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"golang.org/x/exp/slices"
 	"os"
+	"strslicesings"
 	"strings"
 
 	"github.com/spf13/cobra"

--- a/compilation/types/compiled_contract.go
+++ b/compilation/types/compiled_contract.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	"golang.org/x/exp/slices"
 )
 
 // CompiledContract represents a single contract unit from a smart contract compilation.

--- a/fuzzing/calls/call_message.go
+++ b/fuzzing/calls/call_message.go
@@ -2,6 +2,7 @@ package calls
 
 import (
 	"math/big"
+	"slices"
 
 	"github.com/crytic/medusa/chain"
 	"github.com/crytic/medusa/logging"
@@ -9,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
-	"golang.org/x/exp/slices"
 )
 
 // The following directives will be picked up by the `go generate` command to generate JSON marshaling code from

--- a/fuzzing/contracts/contract.go
+++ b/fuzzing/contracts/contract.go
@@ -1,7 +1,7 @@
 package contracts
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 	"strings"
 
 	"github.com/crytic/medusa/compilation/types"

--- a/fuzzing/coverage/coverage_maps.go
+++ b/fuzzing/coverage/coverage_maps.go
@@ -1,8 +1,7 @@
 package coverage
 
 import (
-	"golang.org/x/exp/slices"
-
+	"syslicesnc"
 	"sync"
 
 	compilationTypes "github.com/crytic/medusa/compilation/types"

--- a/fuzzing/coverage/source_analysis.go
+++ b/fuzzing/coverage/source_analysis.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 
 	"github.com/crytic/medusa/compilation/types"
-	"golang.org/x/exp/maps"
 )
 
 // SourceAnalysis describes source code coverage across a list of compilations, after analyzing associated CoverageMaps.

--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -2,6 +2,7 @@ package executiontracer
 
 import (
 	"math/big"
+	"slices"
 
 	"github.com/crytic/medusa/chain"
 	"github.com/crytic/medusa/chain/types"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
-	"golang.org/x/exp/slices"
 )
 
 // CallWithExecutionTrace obtains an execution trace for a given call, on the provided chain, using the state

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,7 +39,6 @@ import (
 	"github.com/crytic/medusa/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/slices"
 )
 
 // Fuzzer represents an Ethereum smart contract fuzzing provider.

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -2,6 +2,7 @@ package fuzzing
 
 import (
 	"fmt"
+	"maps"
 	"math/big"
 	"math/rand"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/crytic/medusa/fuzzing/valuegeneration"
 	"github.com/crytic/medusa/utils"
 	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/maps"
 )
 
 // FuzzerWorker describes a single thread worker utilizing its own go-ethereum test node to run property tests against

--- a/fuzzing/test_case_assertion_provider.go
+++ b/fuzzing/test_case_assertion_provider.go
@@ -2,14 +2,13 @@ package fuzzing
 
 import (
 	"math/big"
+	"slices"
 	"sync"
 
 	"github.com/crytic/medusa/compilation/abiutils"
 	"github.com/crytic/medusa/fuzzing/calls"
 	"github.com/crytic/medusa/fuzzing/config"
 	"github.com/crytic/medusa/fuzzing/contracts"
-
-	"golang.org/x/exp/slices"
 )
 
 // AssertionTestCaseProvider is am AssertionTestCase provider which spawns test cases for every contract method and

--- a/fuzzing/test_case_optimization_provider.go
+++ b/fuzzing/test_case_optimization_provider.go
@@ -3,13 +3,13 @@ package fuzzing
 import (
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 
 	"github.com/crytic/medusa/fuzzing/calls"
 	"github.com/crytic/medusa/fuzzing/contracts"
 	"github.com/crytic/medusa/fuzzing/executiontracer"
 	"github.com/ethereum/go-ethereum/core"
-	"golang.org/x/exp/slices"
 )
 
 // MIN_INT is the minimum value for an int256 in hexadecimal

--- a/fuzzing/test_case_property_provider.go
+++ b/fuzzing/test_case_property_provider.go
@@ -3,13 +3,13 @@ package fuzzing
 import (
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 
 	"github.com/crytic/medusa/fuzzing/calls"
 	"github.com/crytic/medusa/fuzzing/contracts"
 	"github.com/crytic/medusa/fuzzing/executiontracer"
 	"github.com/ethereum/go-ethereum/core"
-	"golang.org/x/exp/slices"
 )
 
 // PropertyTestCaseProvider is a provider for on-chain property tests.

--- a/fuzzing/valuegeneration/generator_mutational.go
+++ b/fuzzing/valuegeneration/generator_mutational.go
@@ -1,11 +1,12 @@
 package valuegeneration
 
 import (
-	"github.com/crytic/medusa/utils"
-	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/slices"
 	"math/big"
 	"math/rand"
+	"slices"
+	
+	"github.com/crytic/medusa/utils"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // MutationalValueGenerator represents a ValueGenerator and ValueMutator for function inputs and call arguments. It

--- a/fuzzing/valuegeneration/value_set.go
+++ b/fuzzing/valuegeneration/value_set.go
@@ -4,12 +4,12 @@ import (
 	"encoding/hex"
 	"github.com/crytic/medusa/utils/reflectionutils"
 	"hash"
+	"maps"
 	"math/big"
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/crypto/sha3"
-	"golang.org/x/exp/maps"
 )
 
 // ValueSet represents potential values of significance within the source code to be used in fuzz tests.


### PR DESCRIPTION

Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.