### PR TITLE
Fix parsing of target balances

### DIFF
--- a/chain/vendored/apply_transaction.go
+++ b/chain/vendored/apply_transaction.go
@@ -99,5 +99,5 @@ func EVMApplyTransaction(msg *Message, config *params.ChainConfig, testChainConf
 	receipt.BlockHash = blockHash
 	receipt.BlockNumber = blockNumber
 	receipt.TransactionIndex = uint(statedb.TxIndex())
-	return receipt, result, err
+	return receipt, result, nil
 }

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -159,7 +159,7 @@ func (cb *ContractBalance) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON marshals a ContractBalance to JSON.
 func (cb ContractBalance) MarshalJSON() ([]byte, error) {
-	return []byte(cb.Int.String()), nil
+	return json.Marshal(cb.Int.String())
 }
 
 // TestingConfig describes the configuration options used for testing

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -118,7 +118,10 @@ type ContractBalance struct {
 // UnmarshalJSON parses JSON data into big.Int from empty strings, hex ("0x"),
 // scientific notation (e/E), and base-10 formats
 func (cb *ContractBalance) UnmarshalJSON(data []byte) error {
-	s := string(data)
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
 
 	// Empty string handling
 	if s == "" {

--- a/fuzzing/config/config_test.go
+++ b/fuzzing/config/config_test.go
@@ -31,3 +31,24 @@ func TestDeserializeBalances(t *testing.T) {
 		}
 	}
 }
+
+func TestSerializeBalances(t *testing.T) {
+	testCases := []struct {
+		input           ContractBalance
+		expectedBalance string
+	}{
+		{ContractBalance{*big.NewInt(0)}, "\"0\""},
+		{ContractBalance{*big.NewInt(1)}, "\"1\""},
+		{ContractBalance{*big.NewInt(0).Mul(big.NewInt(1000000000000000000), big.NewInt(1000000000000000000))}, "\"1000000000000000000000000000000000000\""},
+	}
+
+	for _, tc := range testCases {
+		out, err := json.Marshal(tc.input)
+		if err != nil {
+			t.Errorf("Marshal(%v): unexpected error: %v", tc.input, err)
+		}
+		if string(out) != tc.expectedBalance {
+			t.Errorf("Marshal(%v) = %v, want %v", tc.input, out, tc.expectedBalance)
+		}
+	}
+}

--- a/fuzzing/config/config_test.go
+++ b/fuzzing/config/config_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+)
+
+func TestDeserializeBalances(t *testing.T) {
+	testCases := []struct {
+		input           string
+		expectedBalance ContractBalance
+	}{
+		{"\"\"", ContractBalance{*big.NewInt(0)}},
+		{"\"1\"", ContractBalance{*big.NewInt(1)}},
+		{"\"100\"", ContractBalance{*big.NewInt(100)}},
+		{"\"0\"", ContractBalance{*big.NewInt(0)}},
+		{"\"1e5\"", ContractBalance{*big.NewInt(100000)}},
+		{"\"10E-1\"", ContractBalance{*big.NewInt(1)}},
+		{"\"0x1337\"", ContractBalance{*big.NewInt(4919)}},
+		{"\"0X10\"", ContractBalance{*big.NewInt(16)}},
+	}
+
+	for _, tc := range testCases {
+		var b ContractBalance
+		if err := json.Unmarshal([]byte(tc.input), &b); err != nil {
+			t.Errorf("Unmarshal(%q): unexpected error: %v", tc.input, err)
+		}
+		if b.Cmp(&tc.expectedBalance.Int) != 0 {
+			t.Errorf("Unmarshal(%q) = %v, want %v", tc.input, b, tc.expectedBalance)
+		}
+	}
+}

--- a/fuzzing/config/config_test.go
+++ b/fuzzing/config/config_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 )
 
-func TestDeserializeBalances(t *testing.T) {
+// TestUnmarshalBalances will test the unmarshalling of a ContractBalance from a string
+func TestUnmarshalBalances(t *testing.T) {
+	// Create the list of test cases
 	testCases := []struct {
 		input           string
 		expectedBalance ContractBalance
@@ -21,6 +23,7 @@ func TestDeserializeBalances(t *testing.T) {
 		{"\"0X10\"", ContractBalance{*big.NewInt(16)}},
 	}
 
+	// Iterate over the test cases and unmarshal the input string into a ContractBalance
 	for _, tc := range testCases {
 		var b ContractBalance
 		if err := json.Unmarshal([]byte(tc.input), &b); err != nil {
@@ -32,7 +35,9 @@ func TestDeserializeBalances(t *testing.T) {
 	}
 }
 
-func TestSerializeBalances(t *testing.T) {
+// TestMarshalBalances will test the marshalling of a ContractBalance to a string
+func TestMarshalBalances(t *testing.T) {
+	// Create the list of test cases
 	testCases := []struct {
 		input           ContractBalance
 		expectedBalance string
@@ -42,6 +47,7 @@ func TestSerializeBalances(t *testing.T) {
 		{ContractBalance{*big.NewInt(0).Mul(big.NewInt(1000000000000000000), big.NewInt(1000000000000000000))}, "\"1000000000000000000000000000000000000\""},
 	}
 
+	// Iterate over the test cases and marshal the ContractBalance to a string
 	for _, tc := range testCases {
 		out, err := json.Marshal(tc.input)
 		if err != nil {


### PR DESCRIPTION
The new code was not accounting for the quotes in the JSON strings. This fixes it and adds a few tests for the new supported formats.

Fixes: #591