### PR TITLE
Add Configurable Verbosity Levels for Execution Traces

### DIFF
--- a/cmd/fuzz_flags.go
+++ b/cmd/fuzz_flags.go
@@ -236,11 +236,23 @@ func updateProjectConfigWithFuzzFlags(cmd *cobra.Command, projectConfig *config.
 
 	// Update the verbosity levels
 	if cmd.Flags().Changed("verbosity") || cmd.Flags().Changed("v") {
-		verbosity, err := cmd.Flags().GetCount("verbosity")
+		verbosityCount, err := cmd.Flags().GetCount("verbosity")
 		if err != nil {
 			return err
 		}
-		projectConfig.Fuzzing.Testing.Verbosity = verbosity - 1
+
+		// Map verbosity count to VerbosityLevel enum
+		// -v = Verbose (0)
+		// -vv = VeryVerbose (1)
+		// -vvv = VeryVeryVerbose (2)
+		switch {
+		case verbosityCount == 1:
+			projectConfig.Fuzzing.Testing.Verbosity = config.Verbose
+		case verbosityCount == 2:
+			projectConfig.Fuzzing.Testing.Verbosity = config.VeryVerbose
+		case verbosityCount >= 3:
+			projectConfig.Fuzzing.Testing.Verbosity = config.VeryVeryVerbose
+		}
 	}
 
 	return nil

--- a/cmd/fuzz_flags.go
+++ b/cmd/fuzz_flags.go
@@ -77,8 +77,8 @@ func addFuzzFlags() error {
 	// RPC block
 	fuzzCmd.Flags().Uint64("rpc-block", 0, "block number to use when fetching contracts over RPC")
 
-	// Verbosity levels
-	fuzzCmd.Flags().CountP("verbosity", "v", "use verbose output")
+	// Verbosity levels (-v, -vv, -vvv)
+	fuzzCmd.Flags().CountP("verbosity", "v", "increase verbosity level (can be used multiple times: -v, -vv, -vvv)")
 	return nil
 }
 

--- a/cmd/fuzz_flags.go
+++ b/cmd/fuzz_flags.go
@@ -56,10 +56,6 @@ func addFuzzFlags() error {
 	fuzzCmd.Flags().String("deployer", "",
 		"account address used to deploy contracts")
 
-	// Trace all
-	fuzzCmd.Flags().Bool("trace-all", false,
-		fmt.Sprintf("print the execution trace for every element in a shrunken call sequence instead of only the last element (unless a config file is provided, default is %t)", defaultConfig.Fuzzing.Testing.TraceAll))
-
 	// Logging color
 	fuzzCmd.Flags().Bool("no-color", false, "disables colored terminal output")
 
@@ -80,6 +76,9 @@ func addFuzzFlags() error {
 
 	// RPC block
 	fuzzCmd.Flags().Uint64("rpc-block", 0, "block number to use when fetching contracts over RPC")
+
+	// Verbosity levels
+	fuzzCmd.Flags().CountP("verbosity", "v", "use verbose output")
 	return nil
 }
 
@@ -164,14 +163,6 @@ func updateProjectConfigWithFuzzFlags(cmd *cobra.Command, projectConfig *config.
 		}
 	}
 
-	// Update trace all enablement
-	if cmd.Flags().Changed("trace-all") {
-		projectConfig.Fuzzing.Testing.TraceAll, err = cmd.Flags().GetBool("trace-all")
-		if err != nil {
-			return err
-		}
-	}
-
 	// Update logging color mode
 	if cmd.Flags().Changed("no-color") {
 		projectConfig.Logging.NoColor, err = cmd.Flags().GetBool("no-color")
@@ -241,6 +232,15 @@ func updateProjectConfigWithFuzzFlags(cmd *cobra.Command, projectConfig *config.
 		if err != nil {
 			return err
 		}
+	}
+
+	// Update the verbosity levels
+	if cmd.Flags().Changed("verbosity") || cmd.Flags().Changed("v") {
+		verbosity, err := cmd.Flags().GetCount("verbosity")
+		if err != nil {
+			return err
+		}
+		projectConfig.Fuzzing.Testing.Verbosity = verbosity - 1
 	}
 
 	return nil

--- a/cmd/fuzz_flags.go
+++ b/cmd/fuzz_flags.go
@@ -78,7 +78,7 @@ func addFuzzFlags() error {
 	fuzzCmd.Flags().Uint64("rpc-block", 0, "block number to use when fetching contracts over RPC")
 
 	// Verbosity levels (-v, -vv, -vvv)
-	fuzzCmd.Flags().CountP("verbosity", "v", "increase verbosity level (can be used multiple times: -v, -vv, -vvv)")
+	fuzzCmd.Flags().CountP("verbosity", "v", "set execution trace verbosity levels: -v (top-level calls only), -vv (detailed, default), -vvv (trace all call sequence elements)")
 	return nil
 }
 

--- a/docs/src/cli/fuzz.md
+++ b/docs/src/cli/fuzz.md
@@ -141,15 +141,23 @@ The `--fail-fast` flag enables fast failure (equivalent to
 medusa fuzz --fail-fast
 ```
 
-### `--trace-all`
+### `-v`, `-vv`, `-vvv`
 
-The `--trace-all` flag allows you to retrieve an execution trace for each element of a call sequence that triggered a test
-failure (equivalent to
-[`testing.traceAll`](../project_configuration/testing_config.md#traceall)
+The verbosity flags control the level of detail shown in execution traces (equivalent to [`testing.verbosity`](../project_configuration/testing_config.md#verbosity)):
+
+- `-v`: Shows only top-level transactions in the execution trace. Only events in the top-level call frame and return data are included (Verbose level).
+- `-vv`: Shows nested calls with standard detail - this is the default behavior (VeryVerbose level).
+- `-vvv`: Shows all call sequence elements with maximum detail, attaching traces to every call in the sequence (VeryVeryVerbose level).
 
 ```shell
-# Trace each call
-medusa fuzz --trace-all
+# Set verbosity to top-level only
+medusa fuzz -v
+
+# Set verbosity to nested calls (default)
+medusa fuzz -vv
+
+# Set verbosity to maximum detail
+medusa fuzz -vvv
 ```
 
 ### `--no-color`

--- a/docs/src/project_configuration/testing_config.md
+++ b/docs/src/project_configuration/testing_config.md
@@ -62,12 +62,15 @@ contract MyContract {
   just the contracts specified in the project configuration's [`fuzzing.targetContracts`](./fuzzing_config.md#targetcontracts).
 - **Default**: `false`
 
-### `traceAll`:
+### `verbosity`:
 
-- **Type**: Boolean
-- **Description**: Determines whether an `execution trace` should be attached to each element of a call sequence
-  that triggered a test failure.
-- **Default**: `false`
+- **Type**: Enum (VerbosityLevel)
+- **Description**: Controls the level of detail in execution traces:
+  - **Verbose (0)**: Only shows top-level transactions in the execution trace. Only events in the top-level call frame and return data are included.
+  - **VeryVerbose (1)**: Shows nested calls with standard detail (default behavior).
+  - **VeryVeryVerbose (2)**: Shows all call sequence elements with maximum detail, attaching traces to every call in the sequence.
+- **CLI flags**: Use `-v`, `-vv`, or `-vvv` to set verbosity levels 0, 1, or 2 respectively.
+- **Default**: `VeryVerbose (1)`
 
 ### `targetFunctionSignatures`:
 

--- a/fuzzing/calls/call_sequence_execution.go
+++ b/fuzzing/calls/call_sequence_execution.go
@@ -170,9 +170,9 @@ func ExecuteCallSequence(chain *chain.TestChain, callSequence CallSequence) (Cal
 }
 
 // ExecuteCallSequenceWithExecutionTracer attaches an executiontracer.ExecutionTracer to ExecuteCallSequenceIteratively and attaches execution traces to the call sequence elements.
-func ExecuteCallSequenceWithExecutionTracer(testChain *chain.TestChain, contractDefinitions contracts.Contracts, callSequence CallSequence, verboseTracing bool) (CallSequence, error) {
+func ExecuteCallSequenceWithExecutionTracer(testChain *chain.TestChain, contractDefinitions contracts.Contracts, callSequence CallSequence, verbosity int) (CallSequence, error) {
 	// Create a new execution tracer
-	executionTracer := executiontracer.NewExecutionTracer(contractDefinitions, testChain)
+	executionTracer := executiontracer.NewExecutionTracer(contractDefinitions, testChain, verbosity)
 	defer executionTracer.Close()
 
 	// Execute our sequence with a simple fetch operation provided to obtain each element.
@@ -189,7 +189,7 @@ func ExecuteCallSequenceWithExecutionTracer(testChain *chain.TestChain, contract
 	// By default, we only trace the last element in the call sequence.
 	traceFrom := len(callSequence) - 1
 	// If verbose tracing is enabled, we want to trace all elements in the call sequence.
-	if verboseTracing {
+	if verbosity == 2 {
 		traceFrom = 0
 	}
 

--- a/fuzzing/calls/call_sequence_execution.go
+++ b/fuzzing/calls/call_sequence_execution.go
@@ -189,7 +189,7 @@ func ExecuteCallSequenceWithExecutionTracer(testChain *chain.TestChain, contract
 
 	// Determine which elements of the call sequence to trace based on verbosity level
 	traceFrom := len(callSequence) - 1 // Default: only trace the last element
-	
+
 	// VeryVeryVerbose (level 2): Trace all elements in the call sequence
 	if verbosity == config.VeryVeryVerbose {
 		traceFrom = 0

--- a/fuzzing/calls/call_sequence_execution.go
+++ b/fuzzing/calls/call_sequence_execution.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/crytic/medusa/chain"
+	"github.com/crytic/medusa/fuzzing/config"
 	"github.com/crytic/medusa/fuzzing/contracts"
 	"github.com/crytic/medusa/fuzzing/executiontracer"
 	"github.com/crytic/medusa/utils"
@@ -170,7 +171,7 @@ func ExecuteCallSequence(chain *chain.TestChain, callSequence CallSequence) (Cal
 }
 
 // ExecuteCallSequenceWithExecutionTracer attaches an executiontracer.ExecutionTracer to ExecuteCallSequenceIteratively and attaches execution traces to the call sequence elements.
-func ExecuteCallSequenceWithExecutionTracer(testChain *chain.TestChain, contractDefinitions contracts.Contracts, callSequence CallSequence, verbosity int) (CallSequence, error) {
+func ExecuteCallSequenceWithExecutionTracer(testChain *chain.TestChain, contractDefinitions contracts.Contracts, callSequence CallSequence, verbosity config.VerbosityLevel) (CallSequence, error) {
 	// Create a new execution tracer
 	executionTracer := executiontracer.NewExecutionTracer(contractDefinitions, testChain, verbosity)
 	defer executionTracer.Close()
@@ -186,12 +187,15 @@ func ExecuteCallSequenceWithExecutionTracer(testChain *chain.TestChain, contract
 	// Execute the call sequence and attach the execution tracer
 	executedCallSeq, err := ExecuteCallSequenceIteratively(testChain, fetchElementFunc, nil, executionTracer.NativeTracer())
 
-	// By default, we only trace the last element in the call sequence.
-	traceFrom := len(callSequence) - 1
-	// If verbose tracing is enabled, we want to trace all elements in the call sequence.
-	if verbosity == 2 {
+	// Determine which elements of the call sequence to trace based on verbosity level
+	traceFrom := len(callSequence) - 1 // Default: only trace the last element
+	
+	// VeryVeryVerbose (level 2): Trace all elements in the call sequence
+	if verbosity == config.VeryVeryVerbose {
 		traceFrom = 0
 	}
+	// Note: For Verbose (level 0), only top-level call frames are shown, handled in execution_trace.go
+	// For VeryVerbose (level 1), full detail for the last element is shown (default behavior)
 
 	// Attach the execution trace for each requested call sequence element
 	for ; traceFrom < len(callSequence); traceFrom++ {

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -185,7 +185,11 @@ type TestingConfig struct {
 	// TraceAll describes whether a trace should be attached to each element of a finalized shrunken call sequence,
 	// e.g. when a call sequence triggers a test failure. Test providers may attach execution traces by default,
 	// even if this option is not enabled.
-	TraceAll bool `json:"traceAll"`
+	//TraceAll bool `json:"traceAll"`
+
+	// Verbosity describes the level of verbosity for logging. Higher values mean more verbose output.
+	// 0 = verbose (-v), 1 = (default) very verbose (-vv), 2 = more verbose (-vvv) or equivalent to trace all
+	Verbosity int `json:"verbosity"`
 
 	// AssertionTesting describes the configuration used for assertion testing.
 	AssertionTesting AssertionTestingConfig `json:"assertionTesting"`

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -198,13 +198,11 @@ type TestingConfig struct {
 	// TestViewMethods dictates whether constant/pure/view methods should be called and tested.
 	TestViewMethods bool `json:"testViewMethods"`
 
-	// TraceAll describes whether a trace should be attached to each element of a finalized shrunken call sequence,
-	// e.g. when a call sequence triggers a test failure. Test providers may attach execution traces by default,
-	// even if this option is not enabled.
-	//TraceAll bool `json:"traceAll"`
-
-	// Verbosity describes the level of verbosity for logging. Higher values mean more verbose output.
-	// Verbose (-v), VeryVerbose (-vv),VeryVeryVerbose(TraceAll) (-vvv)
+	// Verbosity controls the level of detail in execution traces:
+	// - Verbose (0): Only shows top-level transactions; hides nested calls
+	// - VeryVerbose (1): Shows nested calls with standard detail (default)
+	// - VeryVeryVerbose (2): Shows all call sequence elements with maximum detail
+	// CLI flags: -v, -vv, -vvv set levels 0, 1, 2 respectively
 	Verbosity VerbosityLevel `json:"verbosity"`
 
 	// AssertionTesting describes the configuration used for assertion testing.

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -169,10 +169,10 @@ const (
 	// Verbose corresponds to (-v) - Only top-level transactions in the execution trace
 	// Only events in the top-level call frame and return data are handled
 	Verbose VerbosityLevel = 0
-	
+
 	// VeryVerbose corresponds to (-vv) - Default behavior, current level of detail
 	VeryVerbose VerbosityLevel = 1
-	
+
 	// VeryVeryVerbose corresponds to (-vvv) - Maximum verbosity
 	// Every call sequence element in the call sequence has a trace
 	VeryVeryVerbose VerbosityLevel = 2

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -162,6 +162,22 @@ func (cb ContractBalance) MarshalJSON() ([]byte, error) {
 	return json.Marshal(cb.Int.String())
 }
 
+// VerbosityLevel defines different verbosity levels
+type VerbosityLevel int
+
+const (
+	// Verbose corresponds to (-v) - Only top-level transactions in the execution trace
+	// Only events in the top-level call frame and return data are handled
+	Verbose VerbosityLevel = 0
+	
+	// VeryVerbose corresponds to (-vv) - Default behavior, current level of detail
+	VeryVerbose VerbosityLevel = 1
+	
+	// VeryVeryVerbose corresponds to (-vvv) - Maximum verbosity
+	// Every call sequence element in the call sequence has a trace
+	VeryVeryVerbose VerbosityLevel = 2
+)
+
 // TestingConfig describes the configuration options used for testing
 type TestingConfig struct {
 	// StopOnFailedTest describes whether the fuzzing.Fuzzer should stop after detecting the first failed test.
@@ -188,8 +204,8 @@ type TestingConfig struct {
 	//TraceAll bool `json:"traceAll"`
 
 	// Verbosity describes the level of verbosity for logging. Higher values mean more verbose output.
-	// 0 = verbose (-v), 1 = (default) very verbose (-vv), 2 = more verbose (-vvv) or equivalent to trace all
-	Verbosity int `json:"verbosity"`
+	// Verbose (-v), VeryVerbose (-vv),VeryVeryVerbose(TraceAll) (-vvv)
+	Verbosity VerbosityLevel `json:"verbosity"`
 
 	// AssertionTesting describes the configuration used for assertion testing.
 	AssertionTesting AssertionTestingConfig `json:"assertionTesting"`

--- a/fuzzing/config/config_defaults.go
+++ b/fuzzing/config/config_defaults.go
@@ -69,7 +69,7 @@ func GetDefaultProjectConfig(platform string) (*ProjectConfig, error) {
 				StopOnNoTests:                true,
 				TestViewMethods:              true,
 				TestAllContracts:             false,
-				TraceAll:                     false,
+				Verbosity:                    1,
 				TargetFunctionSignatures:     []string{},
 				ExcludeFunctionSignatures:    []string{},
 				AssertionTesting: AssertionTestingConfig{

--- a/fuzzing/corpus/corpus_test.go
+++ b/fuzzing/corpus/corpus_test.go
@@ -68,7 +68,7 @@ func getMockCallSequenceElementCall() *calls.CallMessage {
 	return &txn
 }
 
-// testCorpusCallSequencesAreEqual tests whether two CorpusCallSequence objects are equal to each other
+// testCorpusCallSequencesEqual tests whether two CorpusCallSequence objects are equal to each other
 func testCorpusCallSequencesEqual(t *testing.T, expected calls.CallSequence, actual calls.CallSequence) {
 	// Ensure the lengths of both sequences are the same
 	assert.EqualValues(t, len(expected), len(actual), "Different number of calls in sequences")
@@ -79,7 +79,7 @@ func testCorpusCallSequencesEqual(t *testing.T, expected calls.CallSequence, act
 	}
 }
 
-// testCorpusBlockHeadersAreEqual tests whether two CorpusBlockHeader objects are equal to each other
+// testCorpusCallSequenceElementsEqual tests whether two CorpusBlockHeader objects are equal to each other
 func testCorpusCallSequenceElementsEqual(t *testing.T, expected calls.CallSequenceElement, actual calls.CallSequenceElement) {
 	// Make sure the call is equal
 	assert.EqualValues(t, *expected.Call, *actual.Call)

--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -36,6 +36,7 @@ type ExecutionTrace struct {
 	// labels is a mapping that maps an address to its string representation for cleaner execution traces
 	labels map[common.Address]string
 
+	// verbosity describes the verbosity levels of the execution trace
 	verbosity config.VerbosityLevel
 }
 

--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -329,6 +329,11 @@ func (t *ExecutionTrace) generateElementsAndLogsForCallFrame(currentDepth int, c
 	// Create list of elements and logs
 	elements := make([]any, 0)
 	consoleLogs := make([]any, 0)
+	
+	// If verbosity is 0 and this is not a top-level call frame, skip processing this frame
+	if t.verbosity == 0 && currentDepth > 0 {
+		return elements, consoleLogs
+	}
 
 	// Create our current call line prefix (indented by call depth)
 	prefix := strings.Repeat("\t", currentDepth) + " => "
@@ -360,6 +365,7 @@ func (t *ExecutionTrace) generateElementsAndLogsForCallFrame(currentDepth int, c
 		for _, operation := range callFrame.Operations {
 			if childCallFrame, ok := operation.(*CallFrame); ok {
 				// If this is a call frame being entered, generate information recursively.
+				// For verbosity level 0, child frames will handle their own filtering based on depth
 				childOutputLines, childConsoleLogStrings := t.generateElementsAndLogsForCallFrame(currentDepth+1, childCallFrame)
 				elements = append(elements, childOutputLines...)
 				consoleLogs = append(consoleLogs, childConsoleLogStrings...)

--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/crytic/medusa/fuzzing/config"
 	"regexp"
 	"strings"
 
@@ -35,11 +36,11 @@ type ExecutionTrace struct {
 	// labels is a mapping that maps an address to its string representation for cleaner execution traces
 	labels map[common.Address]string
 
-	verbosity int
+	verbosity config.VerbosityLevel
 }
 
 // newExecutionTrace creates and returns a new ExecutionTrace, to be used by the ExecutionTracer.
-func newExecutionTrace(contracts contracts.Contracts, labels map[common.Address]string, verbosity int) *ExecutionTrace {
+func newExecutionTrace(contracts contracts.Contracts, labels map[common.Address]string, verbosity config.VerbosityLevel) *ExecutionTrace {
 	return &ExecutionTrace{
 		TopLevelCallFrame:   nil,
 		contractDefinitions: contracts,
@@ -329,9 +330,9 @@ func (t *ExecutionTrace) generateElementsAndLogsForCallFrame(currentDepth int, c
 	// Create list of elements and logs
 	elements := make([]any, 0)
 	consoleLogs := make([]any, 0)
-	
+
 	// If verbosity is 0 and this is not a top-level call frame, skip processing this frame
-	if t.verbosity == 0 && currentDepth > 0 {
+	if t.verbosity == config.Verbose && currentDepth > 0 {
 		return elements, consoleLogs
 	}
 

--- a/fuzzing/executiontracer/execution_trace.go
+++ b/fuzzing/executiontracer/execution_trace.go
@@ -34,14 +34,17 @@ type ExecutionTrace struct {
 
 	// labels is a mapping that maps an address to its string representation for cleaner execution traces
 	labels map[common.Address]string
+
+	verbosity int
 }
 
 // newExecutionTrace creates and returns a new ExecutionTrace, to be used by the ExecutionTracer.
-func newExecutionTrace(contracts contracts.Contracts, labels map[common.Address]string) *ExecutionTrace {
+func newExecutionTrace(contracts contracts.Contracts, labels map[common.Address]string, verbosity int) *ExecutionTrace {
 	return &ExecutionTrace{
 		TopLevelCallFrame:   nil,
 		contractDefinitions: contracts,
 		labels:              labels,
+		verbosity:           verbosity,
 	}
 }
 

--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -71,6 +71,7 @@ type ExecutionTracer struct {
 	// nativeTracer is the underlying tracer interface that the execution tracer follows
 	nativeTracer *chain.TestChainTracer
 
+	// verbosity describes the verbosity level that will be used for the execution trace
 	verbosity config.VerbosityLevel
 }
 

--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -1,6 +1,7 @@
 package executiontracer
 
 import (
+	"github.com/crytic/medusa/fuzzing/config"
 	"math/big"
 
 	"github.com/crytic/medusa/chain"
@@ -20,7 +21,7 @@ import (
 // CallWithExecutionTrace obtains an execution trace for a given call, on the provided chain, using the state
 // provided. If a nil state is provided, the current chain state will be used.
 // Returns the ExecutionTrace for the call or an error if one occurs.
-func CallWithExecutionTrace(testChain *chain.TestChain, contractDefinitions contracts.Contracts, msg *core.Message, state types.MedusaStateDB, verbosity int) (*core.ExecutionResult, *ExecutionTrace, error) {
+func CallWithExecutionTrace(testChain *chain.TestChain, contractDefinitions contracts.Contracts, msg *core.Message, state types.MedusaStateDB, verbosity config.VerbosityLevel) (*core.ExecutionResult, *ExecutionTrace, error) {
 	// Create an execution tracer
 	executionTracer := NewExecutionTracer(contractDefinitions, testChain, verbosity)
 	defer executionTracer.Close()
@@ -70,11 +71,11 @@ type ExecutionTracer struct {
 	// nativeTracer is the underlying tracer interface that the execution tracer follows
 	nativeTracer *chain.TestChainTracer
 
-	verbosity int
+	verbosity config.VerbosityLevel
 }
 
 // NewExecutionTracer creates a ExecutionTracer and returns it.
-func NewExecutionTracer(contractDefinitions contracts.Contracts, testChain *chain.TestChain, verbosity int) *ExecutionTracer {
+func NewExecutionTracer(contractDefinitions contracts.Contracts, testChain *chain.TestChain, verbosity config.VerbosityLevel) *ExecutionTracer {
 	tracer := &ExecutionTracer{
 		contractDefinitions: contractDefinitions,
 		testChain:           testChain,

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -556,7 +556,7 @@ func chainSetupFromCompilations(fuzzer *Fuzzer, testChain *chain.TestChain) (*ex
 					if err != nil {
 						return nil, fmt.Errorf("failed to reset to genesis block: %v", err)
 					} else {
-						_, err = calls.ExecuteCallSequenceWithExecutionTracer(testChain, fuzzer.contractDefinitions, []*calls.CallSequenceElement{cse}, 2)
+						_, err = calls.ExecuteCallSequenceWithExecutionTracer(testChain, fuzzer.contractDefinitions, []*calls.CallSequenceElement{cse}, config.VeryVeryVerbose)
 						if err != nil {
 							return nil, fmt.Errorf("deploying %s returned a failed status: %v", contractName, block.MessageResults[0].ExecutionResult.Err)
 						}

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -556,7 +556,7 @@ func chainSetupFromCompilations(fuzzer *Fuzzer, testChain *chain.TestChain) (*ex
 					if err != nil {
 						return nil, fmt.Errorf("failed to reset to genesis block: %v", err)
 					} else {
-						_, err = calls.ExecuteCallSequenceWithExecutionTracer(testChain, fuzzer.contractDefinitions, []*calls.CallSequenceElement{cse}, true)
+						_, err = calls.ExecuteCallSequenceWithExecutionTracer(testChain, fuzzer.contractDefinitions, []*calls.CallSequenceElement{cse}, 2)
 						if err != nil {
 							return nil, fmt.Errorf("deploying %s returned a failed status: %v", contractName, block.MessageResults[0].ExecutionResult.Err)
 						}

--- a/fuzzing/fuzzer_hooks.go
+++ b/fuzzing/fuzzer_hooks.go
@@ -1,6 +1,7 @@
 package fuzzing
 
 import (
+	"github.com/crytic/medusa/fuzzing/config"
 	"math/rand"
 
 	"github.com/crytic/medusa/fuzzing/executiontracer"
@@ -67,7 +68,7 @@ type ShrinkCallSequenceRequest struct {
 	VerifierFunction func(worker *FuzzerWorker, callSequence calls.CallSequence) (bool, error)
 	// FinishedCallback is a method called upon when the shrink request has concluded. It provides the finalized
 	// shrunken call sequence.
-	FinishedCallback func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity int) error
+	FinishedCallback func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity config.VerbosityLevel) error
 	// RecordResultInCorpus indicates whether the shrunken call sequence should be recorded in the corpus. If so, when
 	// the shrinking operation is completed, the sequence will be added to the corpus if it doesn't already exist.
 	RecordResultInCorpus bool

--- a/fuzzing/fuzzer_hooks.go
+++ b/fuzzing/fuzzer_hooks.go
@@ -67,7 +67,7 @@ type ShrinkCallSequenceRequest struct {
 	VerifierFunction func(worker *FuzzerWorker, callSequence calls.CallSequence) (bool, error)
 	// FinishedCallback is a method called upon when the shrink request has concluded. It provides the finalized
 	// shrunken call sequence.
-	FinishedCallback func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verboseTracing bool) error
+	FinishedCallback func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity int) error
 	// RecordResultInCorpus indicates whether the shrunken call sequence should be recorded in the corpus. If so, when
 	// the shrinking operation is completed, the sequence will be added to the corpus if it doesn't already exist.
 	RecordResultInCorpus bool

--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -1087,6 +1087,8 @@ func TestVerbosityLevels(t *testing.T) {
 		1: { // VeryVerbose level - should contain nested calls
 			"[call] TestContract.setYValue(uint256)",
 			"[event] settingUpY",
+			"[call] HelperContract.setY(uint256)",
+			"[event] setUpY",
 			"[return (true)]",
 		},
 		2: { // VeryVeryVerbose level - should contain all calls with full detail

--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -482,7 +482,7 @@ func TestDeploymentsWithPredeploy(t *testing.T) {
 	})
 }
 
-// TestDeploymentsWithPayableConstructor runs a test to ensure that we can send ether to payable constructors
+// TestDeploymentsWithPayableConstructors runs a test to ensure that we can send ether to payable constructors
 func TestDeploymentsWithPayableConstructors(t *testing.T) {
 	runFuzzerTest(t, &fuzzerSolcFileTest{
 		filePath: "testdata/contracts/deployments/deploy_payable_constructors.sol",

--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -1080,33 +1080,25 @@ func TestVerbosityLevels(t *testing.T) {
 	// Map to store trace messages for each verbosity level
 	executedTraceMessages := map[int][]string{
 		0: { // Verbose level - should only contain top-level calls
-			"[call] TestMarketplace.buyItem(uint256)",
+			"[call] TestContract.setYValue(uint256)",
+			"[event] settingUpY",
 		},
 		1: { // VeryVerbose level - should contain nested calls
-			"[call] TestMarketplace.buyItem(uint256)",
-			"[call] TestToken.balanceOf(address)",
-			"return",
-			"[call] TestToken.allowance(address,address)",
-			"return",
-			"[call] TestToken.transferFrom(address,address,uint256)",
-			"[event] Transfer",
-			"return",
+			"[call] TestContract.setYValue(uint256)",
+			"[event] settingUpY",
+			"[return (true)]",
 		},
 		2: { // VeryVeryVerbose level - should contain all calls with full detail
-			"[call] TestMarketplace.listItem(uint256,uint256)",
-			"[event] ItemListed",
-			"return ()",
-			"[call] TestToken.approve(address,uint256)",
-			"[event] Approval",
-			"return",
-			"[call] TestMarketplace.buyItem(uint256)",
-			"[call] TestToken.balanceOf(address)",
-			"return",
-			"[call] TestToken.allowance(address,address)",
-			"return",
-			"[call] TestToken.transferFrom(address,address,uint256)",
-			"[event] Transfer",
-			"return",
+			"[call] TestContract.setXValue(uint256)",
+			"[call] HelperContract.setX(uint256)",
+			"[event] setUpX",
+			"[return (true)]",
+			"[return ()]",
+			"[call] TestContract.setYValue(uint256)",
+			"[event] settingUpY",
+			"[call] HelperContract.setY(uint256)",
+			"[event] setUpY",
+			"[return (true)]",
 		},
 	}
 	verbosityTests := []config.VerbosityLevel{config.Verbose, config.VeryVerbose, config.VeryVeryVerbose}
@@ -1115,20 +1107,11 @@ func TestVerbosityLevels(t *testing.T) {
 		runFuzzerTest(t, &fuzzerSolcFileTest{
 			filePath: "testdata/contracts/execution_tracing/verbosity_levels.sol",
 			configUpdates: func(projectConfig *config.ProjectConfig) {
-				projectConfig.Fuzzing.TargetContracts = []string{"TestToken", "TestMarketplace"}
+				projectConfig.Fuzzing.TargetContracts = []string{"TestContract", "HelperContract"}
 				projectConfig.Fuzzing.Testing.AssertionTesting.Enabled = true
 				projectConfig.Fuzzing.Testing.PropertyTesting.Enabled = false
 				projectConfig.Fuzzing.Testing.OptimizationTesting.Enabled = false
 				projectConfig.Slither.UseSlither = false
-				projectConfig.Fuzzing.ConstructorArgs = map[string]map[string]any{
-					"TestToken": {
-						"_name":          "test_token",
-						"_initialSupply": "100000000",
-					},
-					"TestMarketplace": {
-						"_paymentToken": "DeployedContract:TestToken",
-					},
-				}
 				// Start with a default verbosity
 				projectConfig.Fuzzing.Testing.Verbosity = config.VerbosityLevel(verbosityLevel)
 			},

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -547,7 +547,7 @@ func (fw *FuzzerWorker) shrinkCallSequence(shrinkRequest ShrinkCallSequenceReque
 	// Shrinking is complete. If our config specified we want all result sequences to have execution traces attached,
 	// attach them now to each element in the sequence. Otherwise, call sequences will only have traces that the
 	// test providers choose to attach themselves.
-	err = shrinkRequest.FinishedCallback(fw, optimizedSequence, fw.fuzzer.config.Fuzzing.Testing.TraceAll)
+	err = shrinkRequest.FinishedCallback(fw, optimizedSequence, fw.fuzzer.config.Fuzzing.Testing.Verbosity)
 	if err != nil {
 		return nil, err
 	}

--- a/fuzzing/test_case_assertion_provider.go
+++ b/fuzzing/test_case_assertion_provider.go
@@ -203,7 +203,7 @@ func (t *AssertionTestCaseProvider) callSequencePostCallTest(worker *FuzzerWorke
 				// If we encountered assertion failures on the same method, this shrunk sequence is satisfactory.
 				return shrunkSeqTestFailed && *methodId == *shrunkSeqMethodId, nil
 			},
-			FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity int) error {
+			FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity config.VerbosityLevel) error {
 				// When we're finished shrinking, attach an execution trace to the last call. If verboseTracing is true, attach to all calls.
 				if len(shrunkenCallSequence) > 0 {
 					_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verbosity)

--- a/fuzzing/test_case_assertion_provider.go
+++ b/fuzzing/test_case_assertion_provider.go
@@ -203,10 +203,10 @@ func (t *AssertionTestCaseProvider) callSequencePostCallTest(worker *FuzzerWorke
 				// If we encountered assertion failures on the same method, this shrunk sequence is satisfactory.
 				return shrunkSeqTestFailed && *methodId == *shrunkSeqMethodId, nil
 			},
-			FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verboseTracing bool) error {
+			FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity int) error {
 				// When we're finished shrinking, attach an execution trace to the last call. If verboseTracing is true, attach to all calls.
 				if len(shrunkenCallSequence) > 0 {
-					_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verboseTracing)
+					_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verbosity)
 					if err != nil {
 						return err
 					}

--- a/fuzzing/test_case_optimization_provider.go
+++ b/fuzzing/test_case_optimization_provider.go
@@ -94,7 +94,7 @@ func (t *OptimizationTestCaseProvider) runOptimizationTest(worker *FuzzerWorker,
 	var executionResult *core.ExecutionResult
 	var executionTrace *executiontracer.ExecutionTrace
 	if trace {
-		executionResult, executionTrace, err = executiontracer.CallWithExecutionTrace(worker.chain, worker.fuzzer.contractDefinitions, msg.ToCoreMessage(), nil)
+		executionResult, executionTrace, err = executiontracer.CallWithExecutionTrace(worker.chain, worker.fuzzer.contractDefinitions, msg.ToCoreMessage(), nil, worker.fuzzer.config.Fuzzing.Testing.Verbosity)
 	} else {
 		executionResult, err = worker.Chain().CallContract(msg.ToCoreMessage(), nil)
 	}
@@ -344,10 +344,10 @@ func (t *OptimizationTestCaseProvider) callSequencePostCallTest(worker *FuzzerWo
 
 					return shrunkenSequenceNewValue.Cmp(newValue) >= 0, err
 				},
-				FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verboseTracing bool) error {
+				FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity int) error {
 					// When we're finished shrinking, attach an execution trace to the last call. If verboseTracing is true, attach to all calls.
 					if len(shrunkenCallSequence) > 0 {
-						_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verboseTracing)
+						_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verbosity)
 						if err != nil {
 							return err
 						}

--- a/fuzzing/test_case_optimization_provider.go
+++ b/fuzzing/test_case_optimization_provider.go
@@ -2,6 +2,7 @@ package fuzzing
 
 import (
 	"fmt"
+	"github.com/crytic/medusa/fuzzing/config"
 	"math/big"
 	"sync"
 
@@ -344,7 +345,7 @@ func (t *OptimizationTestCaseProvider) callSequencePostCallTest(worker *FuzzerWo
 
 					return shrunkenSequenceNewValue.Cmp(newValue) >= 0, err
 				},
-				FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity int) error {
+				FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity config.VerbosityLevel) error {
 					// When we're finished shrinking, attach an execution trace to the last call. If verboseTracing is true, attach to all calls.
 					if len(shrunkenCallSequence) > 0 {
 						_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verbosity)

--- a/fuzzing/test_case_property_provider.go
+++ b/fuzzing/test_case_property_provider.go
@@ -2,6 +2,7 @@ package fuzzing
 
 import (
 	"fmt"
+	"github.com/crytic/medusa/fuzzing/config"
 	"math/big"
 	"sync"
 
@@ -312,7 +313,7 @@ func (t *PropertyTestCaseProvider) callSequencePostCallTest(worker *FuzzerWorker
 					shrunkenSequenceFailedTest, _, err := t.checkPropertyTestFailed(worker, &workerPropertyTestMethod, false)
 					return shrunkenSequenceFailedTest, err
 				},
-				FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity int) error {
+				FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity config.VerbosityLevel) error {
 					// When we're finished shrinking, attach an execution trace to the last call. If verboseTracing is true, attach to all calls.
 					if len(shrunkenCallSequence) > 0 {
 						_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verbosity)

--- a/fuzzing/test_case_property_provider.go
+++ b/fuzzing/test_case_property_provider.go
@@ -88,7 +88,7 @@ func (t *PropertyTestCaseProvider) checkPropertyTestFailed(worker *FuzzerWorker,
 	var executionResult *core.ExecutionResult
 	var executionTrace *executiontracer.ExecutionTrace
 	if trace {
-		executionResult, executionTrace, err = executiontracer.CallWithExecutionTrace(worker.chain, worker.fuzzer.contractDefinitions, msg.ToCoreMessage(), nil)
+		executionResult, executionTrace, err = executiontracer.CallWithExecutionTrace(worker.chain, worker.fuzzer.contractDefinitions, msg.ToCoreMessage(), nil, worker.fuzzer.config.Fuzzing.Testing.Verbosity)
 	} else {
 		executionResult, err = worker.Chain().CallContract(msg.ToCoreMessage(), nil)
 	}
@@ -312,10 +312,10 @@ func (t *PropertyTestCaseProvider) callSequencePostCallTest(worker *FuzzerWorker
 					shrunkenSequenceFailedTest, _, err := t.checkPropertyTestFailed(worker, &workerPropertyTestMethod, false)
 					return shrunkenSequenceFailedTest, err
 				},
-				FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verboseTracing bool) error {
+				FinishedCallback: func(worker *FuzzerWorker, shrunkenCallSequence calls.CallSequence, verbosity int) error {
 					// When we're finished shrinking, attach an execution trace to the last call. If verboseTracing is true, attach to all calls.
 					if len(shrunkenCallSequence) > 0 {
-						_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verboseTracing)
+						_, err = calls.ExecuteCallSequenceWithExecutionTracer(worker.chain, worker.fuzzer.contractDefinitions, shrunkenCallSequence, verbosity)
 						if err != nil {
 							return err
 						}

--- a/fuzzing/testdata/contracts/execution_tracing/verbosity_levels.sol
+++ b/fuzzing/testdata/contracts/execution_tracing/verbosity_levels.sol
@@ -3,223 +3,129 @@ pragma solidity ^0.8.0;
 
 /**
  * @title Verbosity Levels Test Contract
- * @dev This file contains contracts specifically designed to test Medusa's verbosity levels:
- *
- * - Verbose (Level 0): Only shows top-level calls, hides nested calls
- * - VeryVerbose (Level 1): Shows nested calls with event and return data (default)
- * - VeryVeryVerbose (Level 2): Shows all call sequence elements with event and return data
- *
- * The test creates a complex call structure with nested function calls across multiple contracts:
- * 1. TestMarketplace.buyItem calls an internal function _processPayment
- * 2. _processPayment calls external functions on the TestToken contract:
- *    - balanceOf (view function)
- *    - allowance (view function)
- *    - transferFrom (state-changing function that emits an event)
- * 3. An assertion failure occurs in _processPayment (line 122)
- *
- * This structure allows us to verify that each verbosity level correctly:
- * - Shows/hides the appropriate level of call depth
- * - Includes/excludes internal function calls
- * - Shows traced events at different verbosity levels
+ * @dev This contract is specifically designed to test Medusa's verbosity levels:
+ * 
+ * - Verbose (0): Only shows top-level calls and their events/return data
+ *   (Events from HelperContract won't be visible, but events from TestContract will)
+ * 
+ * - VeryVerbose (1): Shows nested calls and their events/return data in last element
+ *   (Shows TestContract -> HelperContract calls and all events in the failing transaction)
+ * 
+ * - VeryVeryVerbose (2): Shows all call sequences with complete event/return data
+ *   (Shows setup calls like setXValue + the failing transaction with all details)
+ * 
+ * The test creates a multi-step sequence:
+ * 1. Setup: Call setXValue which calls helper.setX
+ * 2. Main call: setYValue which calls _processYValue
+ * 3. Nested call: _processYValue calls helper.setY
+ * 4. Assertion fails in _processYValue
  */
-
-// CheatCodes interface for Medusa - similar to Foundry's VM
-interface CheatCodes {
-    function prank(address) external;
-    function startPrank(address) external;
-    function stopPrank() external;
-    function deal(address who, uint256 newBalance) external;
-    function warp(uint256) external;
-    function roll(uint256) external;
-}
 
 /**
- * @title TestToken
- * @dev Simple ERC20 token contract that will be called by the TestMarketplace
- * This contract has both view and non-view functions with events to test
- * different verbosity levels of execution tracing
+ * @title HelperContract
+ * @dev Secondary contract that's called by the main contract
+ * Used to test nested call visibility in different verbosity levels
  */
-contract TestToken {
-    string public name;
-    uint256 public totalSupply;
-    mapping(address => uint256) private balances;
-    mapping(address => mapping(address => uint256)) private allowances;
+contract HelperContract {
+    uint256 xValue;
+    uint256 yValue;
+    
+    // Events that will be emitted during calls
+    // These should be visible in VeryVerbose and VeryVeryVerbose modes
+    // but NOT in Verbose mode (since they're from nested calls)
+    event setUpX(uint256 xValue);
+    event setUpY(uint256 yValue);
 
-    event Transfer(address indexed from, address indexed to, uint256 value);
-    event Approval(address indexed owner, address indexed spender, uint256 value);
-
-    constructor(string memory _name, uint256 _initialSupply) {
-        name = _name;
-        totalSupply = _initialSupply;
-        balances[msg.sender] = _initialSupply;
-        emit Transfer(address(0), msg.sender, _initialSupply);
+    constructor() {
+        xValue = 0;
+        yValue = 0;
     }
-
+    
     /**
-     * @dev View function to check balance
-     * This function will be called by the TestMarketplace
-     * For verbosity testing, this tests if view function calls are properly shown/hidden
+     * @dev Sets the x value and emits an event
+     * @param newValue The new value to set
+     * @return true if successful
      */
-    function balanceOf(address account) public view returns (uint256) {
-        return balances[account];
-    }
-
-    /**
-     * @dev Transfer function that emits an event
-     * Not directly called in our test scenario, but illustrates a basic token transfer
-     */
-    function transfer(address to, uint256 amount) public returns (bool) {
-        require(balances[msg.sender] >= amount, "Insufficient balance");
-        balances[msg.sender] -= amount;
-        balances[to] += amount;
-        emit Transfer(msg.sender, to, amount);
+    function setX(uint256 newValue) public returns (bool) {
+        xValue = newValue;
+        emit setUpX(xValue);
         return true;
     }
-
+    
     /**
-     * @dev Approve function called as part of setup
-     * Emits an Approval event which should be visible in higher verbosity levels
+     * @dev Sets the y value and emits an event
+     * @param newValue The new value to set
+     * @return true if successful
      */
-    function approve(address spender, uint256 amount) public returns (bool) {
-        allowances[msg.sender][spender] = amount;
-        emit Approval(msg.sender, spender, amount);
-        return true;
-    }
-
-    /**
-     * @dev View function to check allowance
-     * Called by TestMarketplace's _processPayment function
-     */
-    function allowance(address owner, address spender) public view returns (uint256) {
-        return allowances[owner][spender];
-    }
-
-    /**
-     * @dev TransferFrom function that will be called by TestMarketplace
-     * This is a nested call that should be visible in VeryVerbose and VeryVeryVerbose modes
-     * The event emitted here should also be visible in those modes
-     */
-    function transferFrom(address from, address to, uint256 amount) public returns (bool) {
-        require(balances[from] >= amount, "Insufficient balance");
-        require(allowances[from][msg.sender] >= amount, "Insufficient allowance");
-
-        balances[from] -= amount;
-        balances[to] += amount;
-        allowances[from][msg.sender] -= amount;
-
-        // This event should be visible in the trace at higher verbosity levels
-        emit Transfer(from, to, amount);
+    function setY(uint256 newValue) public returns (bool) {
+        yValue = newValue;
+        emit setUpY(yValue);
         return true;
     }
 }
 
 /**
- * @title TestMarketplace
- * @dev Marketplace contract that creates a complex call structure with the TestToken
- * This contract is designed to test different verbosity levels in Medusa's execution tracing
- * by creating:
- * 1. Top-level calls (buyItem)
- * 2. Internal function calls (_processPayment)
- * 3. Cross-contract calls to TestToken (balanceOf, allowance, transferFrom)
- * 4. Event emissions at different levels
- * 5. An assertion failure deep in the call stack
+ * @title TestContract
+ * @dev Main contract that creates a nested call structure
+ * The pattern of calls is designed to test different verbosity levels
  */
-contract TestMarketplace {
-    struct Listing {
-        uint256 price;
-        address seller;
-        bool active;
-    }
+contract TestContract {
+    HelperContract public helper;
+    bool isXValueSet;
+    bool isYValueSet;
 
-    mapping(uint256 => Listing) public listings;
-    TestToken public paymentToken;
+    event settingUpY(uint256 yValue);
+    event setUpCompleted();
 
-    // Events that will be emitted during testing
-    // These should be visible at different verbosity levels
-    event ItemListed(uint256 indexed itemId, address indexed seller, uint256 price);
-    event ItemSold(uint256 indexed itemId, address indexed seller, address indexed buyer, uint256 price);
-    event ItemDelisted(uint256 indexed itemId);
-
-    constructor(address _paymentToken) {
-        paymentToken = TestToken(_paymentToken);
+    constructor() {
+        helper = new HelperContract();
     }
 
     /**
-     * @dev Creates a listing that can be bought
-     * This function will be part of the setup call sequence
-     * In VeryVeryVerbose mode, this call and its emitted event should be traced
+     * @dev Setup function that will be called first
+     * @param value The x value to set
      */
-    function listItem(uint256 itemId, uint256 price) public {
-        require(price > 0, "Price must be positive");
-        require(!listings[itemId].active, "Item already listed");
-
-        listings[itemId] = Listing({
-            price: price,
-            seller: msg.sender,
-            active: true
-        });
-
-        // This event should be visible in the trace at the highest verbosity level
-        emit ItemListed(itemId, msg.sender, price);
-    }
-
-    /**
-     * @dev Top-level function that triggers complex nested calls
-     * This is the main entry point that Medusa will call during testing
-     * It's a top-level call that should appear in ALL verbosity levels
-     */
-    function buyItem(uint256 itemId) public {
-        Listing memory listing = listings[itemId];
-        require(listing.active, "Item not listed");
-
-        // Call an internal function to handle payment
-        // This internal call tests if internal function calls are properly shown/hidden
-        _processPayment(listing.seller, msg.sender, listing.price);
-
-        // Mark item as sold
-        listings[itemId].active = false;
-
-        // This event should be visible in the trace in ALL verbosity levels
-        emit ItemSold(itemId, listing.seller, msg.sender, listing.price);
-    }
-
-    /**
-     * @dev Internal function that makes cross-contract calls and contains an assertion
-     * This creates a multi-level call structure to test verbosity levels:
-     * 1. Internal call from buyItem
-     * 2. External calls to TestToken (balanceOf, allowance, transferFrom)
-     * 3. Contains assertion failure for testing
-     */
-    function _processPayment(address seller, address buyer, uint256 amount) internal {
-        // External call to view function - tests if nested view calls are traced
-        uint256 buyerBalance = paymentToken.balanceOf(buyer);
-        require(buyerBalance >= amount, "Insufficient balance");
-
-        // Another external call to view function
-        uint256 buyerAllowance = paymentToken.allowance(buyer, address(this));
-        require(buyerAllowance >= amount, "Insufficient allowance");
-
-        // External call that modifies state and emits an event
-        bool success = paymentToken.transferFrom(buyer, seller, amount);
+    function setXValue(uint256 value) public {
+        require(value > 0, "Value should be greater than 0");
         
-        // This assertion will fail, causing a test failure
-        // It's located deep in the call stack to test if execution traces
-        // properly show the failure location at different verbosity levels
+        // Call the helper - nested call should only be visible in VeryVeryVerbose
+        helper.setX(value);
+        
+        // Set flag to indicate successful setup
+        isXValueSet = true;
+    }
+
+    /**
+     * @dev Main function that triggers the failing transaction
+     * @param value The y value to set
+     * @return true if successful (never returns due to assertion failure)
+     */
+    function setYValue(uint256 value) public returns (bool) {
+        // Check if setup was completed
+        require(isXValueSet, "X Value is not set");
+        emit settingUpY(value);
+
+        // Call internal function - tests internal call visibility
+        // This call should NOT be visible in Verbose mode
+        // but SHOULD be visible in VeryVerbose and VeryVeryVerbose modes
+        _processYValue(value);
+
+        emit setUpCompleted();
+        isXValueSet = false;
+        isYValueSet = false;
+        return true;
+    }
+    
+    /**
+     * @dev Internal function that makes a nested call and then fails
+     * @param yValue The value to process
+     */
+    function _processYValue(uint256 yValue) internal {
+        require(yValue > 0, "Y value should be greater than zero");
+        bool success = helper.setY(yValue);
+        isYValueSet = true;
+
+        // Assertion failure - tests trace at failure point
         assert(false);
-        
-        require(success, "Transfer failed");
-    }
-
-    /**
-     * @dev Function to delist an item
-     * Not directly used in our verbosity tests
-     */
-    function delistItem(uint256 itemId) public {
-        require(listings[itemId].active, "Item not listed");
-        require(listings[itemId].seller == msg.sender, "Not the seller");
-
-        listings[itemId].active = false;
-
-        emit ItemDelisted(itemId);
     }
 }

--- a/fuzzing/testdata/contracts/execution_tracing/verbosity_levels.sol
+++ b/fuzzing/testdata/contracts/execution_tracing/verbosity_levels.sol
@@ -105,11 +105,7 @@ contract TestContract {
         require(isXValueSet, "X Value is not set");
         emit settingUpY(value);
 
-        // Call internal function - tests internal call visibility
-        // This call should NOT be visible in Verbose mode
-        // but SHOULD be visible in VeryVerbose and VeryVeryVerbose modes
         _processYValue(value);
-
         emit setUpCompleted();
         isXValueSet = false;
         isYValueSet = false;

--- a/fuzzing/testdata/contracts/execution_tracing/verbosity_levels.sol
+++ b/fuzzing/testdata/contracts/execution_tracing/verbosity_levels.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title Verbosity Levels Test Contract
+ * @dev This file contains contracts specifically designed to test Medusa's verbosity levels:
+ *
+ * - Verbose (Level 0): Only shows top-level calls, hides nested calls
+ * - VeryVerbose (Level 1): Shows nested calls with event and return data (default)
+ * - VeryVeryVerbose (Level 2): Shows all call sequence elements with event and return data
+ *
+ * The test creates a complex call structure with nested function calls across multiple contracts:
+ * 1. TestMarketplace.buyItem calls an internal function _processPayment
+ * 2. _processPayment calls external functions on the TestToken contract:
+ *    - balanceOf (view function)
+ *    - allowance (view function)
+ *    - transferFrom (state-changing function that emits an event)
+ * 3. An assertion failure occurs in _processPayment (line 122)
+ *
+ * This structure allows us to verify that each verbosity level correctly:
+ * - Shows/hides the appropriate level of call depth
+ * - Includes/excludes internal function calls
+ * - Shows traced events at different verbosity levels
+ */
+
+// CheatCodes interface for Medusa - similar to Foundry's VM
+interface CheatCodes {
+    function prank(address) external;
+    function startPrank(address) external;
+    function stopPrank() external;
+    function deal(address who, uint256 newBalance) external;
+    function warp(uint256) external;
+    function roll(uint256) external;
+}
+
+/**
+ * @title TestToken
+ * @dev Simple ERC20 token contract that will be called by the TestMarketplace
+ * This contract has both view and non-view functions with events to test
+ * different verbosity levels of execution tracing
+ */
+contract TestToken {
+    string public name;
+    uint256 public totalSupply;
+    mapping(address => uint256) private balances;
+    mapping(address => mapping(address => uint256)) private allowances;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(string memory _name, uint256 _initialSupply) {
+        name = _name;
+        totalSupply = _initialSupply;
+        balances[msg.sender] = _initialSupply;
+        emit Transfer(address(0), msg.sender, _initialSupply);
+    }
+
+    /**
+     * @dev View function to check balance
+     * This function will be called by the TestMarketplace
+     * For verbosity testing, this tests if view function calls are properly shown/hidden
+     */
+    function balanceOf(address account) public view returns (uint256) {
+        return balances[account];
+    }
+
+    /**
+     * @dev Transfer function that emits an event
+     * Not directly called in our test scenario, but illustrates a basic token transfer
+     */
+    function transfer(address to, uint256 amount) public returns (bool) {
+        require(balances[msg.sender] >= amount, "Insufficient balance");
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    /**
+     * @dev Approve function called as part of setup
+     * Emits an Approval event which should be visible in higher verbosity levels
+     */
+    function approve(address spender, uint256 amount) public returns (bool) {
+        allowances[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev View function to check allowance
+     * Called by TestMarketplace's _processPayment function
+     */
+    function allowance(address owner, address spender) public view returns (uint256) {
+        return allowances[owner][spender];
+    }
+
+    /**
+     * @dev TransferFrom function that will be called by TestMarketplace
+     * This is a nested call that should be visible in VeryVerbose and VeryVeryVerbose modes
+     * The event emitted here should also be visible in those modes
+     */
+    function transferFrom(address from, address to, uint256 amount) public returns (bool) {
+        require(balances[from] >= amount, "Insufficient balance");
+        require(allowances[from][msg.sender] >= amount, "Insufficient allowance");
+
+        balances[from] -= amount;
+        balances[to] += amount;
+        allowances[from][msg.sender] -= amount;
+
+        // This event should be visible in the trace at higher verbosity levels
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}
+
+/**
+ * @title TestMarketplace
+ * @dev Marketplace contract that creates a complex call structure with the TestToken
+ * This contract is designed to test different verbosity levels in Medusa's execution tracing
+ * by creating:
+ * 1. Top-level calls (buyItem)
+ * 2. Internal function calls (_processPayment)
+ * 3. Cross-contract calls to TestToken (balanceOf, allowance, transferFrom)
+ * 4. Event emissions at different levels
+ * 5. An assertion failure deep in the call stack
+ */
+contract TestMarketplace {
+    struct Listing {
+        uint256 price;
+        address seller;
+        bool active;
+    }
+
+    mapping(uint256 => Listing) public listings;
+    TestToken public paymentToken;
+
+    // Events that will be emitted during testing
+    // These should be visible at different verbosity levels
+    event ItemListed(uint256 indexed itemId, address indexed seller, uint256 price);
+    event ItemSold(uint256 indexed itemId, address indexed seller, address indexed buyer, uint256 price);
+    event ItemDelisted(uint256 indexed itemId);
+
+    constructor(address _paymentToken) {
+        paymentToken = TestToken(_paymentToken);
+    }
+
+    /**
+     * @dev Creates a listing that can be bought
+     * This function will be part of the setup call sequence
+     * In VeryVeryVerbose mode, this call and its emitted event should be traced
+     */
+    function listItem(uint256 itemId, uint256 price) public {
+        require(price > 0, "Price must be positive");
+        require(!listings[itemId].active, "Item already listed");
+
+        listings[itemId] = Listing({
+            price: price,
+            seller: msg.sender,
+            active: true
+        });
+
+        // This event should be visible in the trace at the highest verbosity level
+        emit ItemListed(itemId, msg.sender, price);
+    }
+
+    /**
+     * @dev Top-level function that triggers complex nested calls
+     * This is the main entry point that Medusa will call during testing
+     * It's a top-level call that should appear in ALL verbosity levels
+     */
+    function buyItem(uint256 itemId) public {
+        Listing memory listing = listings[itemId];
+        require(listing.active, "Item not listed");
+
+        // Call an internal function to handle payment
+        // This internal call tests if internal function calls are properly shown/hidden
+        _processPayment(listing.seller, msg.sender, listing.price);
+
+        // Mark item as sold
+        listings[itemId].active = false;
+
+        // This event should be visible in the trace in ALL verbosity levels
+        emit ItemSold(itemId, listing.seller, msg.sender, listing.price);
+    }
+
+    /**
+     * @dev Internal function that makes cross-contract calls and contains an assertion
+     * This creates a multi-level call structure to test verbosity levels:
+     * 1. Internal call from buyItem
+     * 2. External calls to TestToken (balanceOf, allowance, transferFrom)
+     * 3. Contains assertion failure for testing
+     */
+    function _processPayment(address seller, address buyer, uint256 amount) internal {
+        // External call to view function - tests if nested view calls are traced
+        uint256 buyerBalance = paymentToken.balanceOf(buyer);
+        require(buyerBalance >= amount, "Insufficient balance");
+
+        // Another external call to view function
+        uint256 buyerAllowance = paymentToken.allowance(buyer, address(this));
+        require(buyerAllowance >= amount, "Insufficient allowance");
+
+        // External call that modifies state and emits an event
+        bool success = paymentToken.transferFrom(buyer, seller, amount);
+        
+        // This assertion will fail, causing a test failure
+        // It's located deep in the call stack to test if execution traces
+        // properly show the failure location at different verbosity levels
+        assert(false);
+        
+        require(success, "Transfer failed");
+    }
+
+    /**
+     * @dev Function to delist an item
+     * Not directly used in our verbosity tests
+     */
+    function delistItem(uint256 itemId) public {
+        require(listings[itemId].active, "Item not listed");
+        require(listings[itemId].seller == msg.sender, "Not the seller");
+
+        listings[itemId].active = false;
+
+        emit ItemDelisted(itemId);
+    }
+}


### PR DESCRIPTION
Summary

This PR introduces three distinct verbosity levels for execution traces in Medusa, giving users more control over the level of detail shown in trace outputs. This is especially beneficial for complex systems with multiple call frames, where the current trace output can be overwhelming.

Changes

  - Added an enumerated VerbosityLevel type with three levels:
    - Verbose (0): Shows only top-level transactions in execution traces. Only events in the top-level call frame and return data are handled.
    - VeryVerbose (1): The current behavior (now default). Shows full detail for the current transaction.
    - VeryVeryVerbose (2): Shows full trace details for all call sequence elements, not just the last one (traceAll).
  - Added comprehensive test contracts and tests to verify the behavior of each verbosity level