### PR TITLE
Fix `go install` installation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.2.0"
+const version = "1.2.1"
 
 // rootCmd represents the root CLI command object which all other commands stem from.
 var rootCmd = &cobra.Command{

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,9 @@
       packages = {
         medusa = pkgs.buildGoModule {
           pname = "medusa";
-          version = "1.2.0";
+          version = "1.2.1";
           src = ./.;
-          vendorHash = "sha256-YGmXDn/sFOM/vEPpDRJwl275wz9DLe/aGNL104Qnjww=";
+          vendorHash = "sha256-utOYL3f4+cpTBHqeuWtd07K1ytLR5cUaZ1hsTEcjpBQ=";
           nativeBuildInputs = [
             crytic.packages.${system}.crytic-compile
             crytic.packages.${system}.slither

--- a/go.mod
+++ b/go.mod
@@ -90,5 +90,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-replace github.com/ethereum/go-ethereum => github.com/crytic/medusa-geth v0.0.0-20250202002730-6e6ee9a60299


### PR DESCRIPTION
```sh
$ go install github.com/crytic/medusa@latest
go: github.com/crytic/medusa@latest (in github.com/crytic/medusa@v1.2.0):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

This is caused by a leftover replace in `go.mod`. Medusa no longer references `github.com/ethereum/go-ethereum` so it should be ok to remove.