### PR TITLE
Synchronize writes while running cmd to avoid data race

### DIFF
--- a/utils/process_utils.go
+++ b/utils/process_utils.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os/exec"
 	"runtime"
+	"sync"
 )
 
 // RunCommandWithOutputAndError runs a given exec.Cmd and returns the stdout, stderr, and
@@ -13,9 +14,12 @@ func RunCommandWithOutputAndError(command *exec.Cmd) ([]byte, []byte, []byte, er
 	// Create our buffers to capture output and errors.
 	var bStdout, bStderr, bCombined bytes.Buffer
 
+	// Create a synchronized writer over bCombined to avoid data race.
+	var combinedWriter io.Writer = &synchronizedWriter{writer: &bCombined}
+
 	// Create multi writers to capture output into individual and combined buffers
-	stdoutMulti := io.MultiWriter(&bStdout, &bCombined)
-	stderrMulti := io.MultiWriter(&bStderr, &bCombined)
+	stdoutMulti := io.MultiWriter(&bStdout, combinedWriter)
+	stderrMulti := io.MultiWriter(&bStderr, combinedWriter)
 
 	// Set our writers
 	command.Stdout = stdoutMulti
@@ -41,4 +45,16 @@ func IsMacOSEnvironment() bool {
 // IsLinuxEnvironment returns a boolean indicating whether the current execution environment is a Linux platform.
 func IsLinuxEnvironment() bool {
 	return runtime.GOOS == "linux"
+}
+
+// synchronizedWriter wraps an io.Writer to avoid a data race when writing.
+type synchronizedWriter struct {
+	writer io.Writer
+	mutex  sync.Mutex
+}
+
+func (s *synchronizedWriter) Write(p []byte) (n int, err error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.writer.Write(p)
 }


### PR DESCRIPTION
Resolves one instance of #269, but there's still some others