### PR TITLE
Ignore contract address in coverage when the contract was created at runtime

### DIFF
--- a/fuzzing/corpus/corpus.go
+++ b/fuzzing/corpus/corpus.go
@@ -345,6 +345,8 @@ func (c *Corpus) Initialize(baseTestChain *chain.TestChain, contractDefinitions 
 		return 0, 0, fmt.Errorf("failed to initialize coverage maps, base test chain cloning encountered error: %v", err)
 	}
 
+	// Freeze a set of deployedContracts's keys so that we have a set of addresses present in baseTestChain.
+	// Feed this set to the coverage tracer.
 	initialContractsSet := make(map[common.Address]struct{}, len(deployedContracts))
 	for addr := range deployedContracts {
 		initialContractsSet[addr] = struct{}{}

--- a/fuzzing/corpus/corpus.go
+++ b/fuzzing/corpus/corpus.go
@@ -345,6 +345,12 @@ func (c *Corpus) Initialize(baseTestChain *chain.TestChain, contractDefinitions 
 		return 0, 0, fmt.Errorf("failed to initialize coverage maps, base test chain cloning encountered error: %v", err)
 	}
 
+	initialContractsSet := make(map[common.Address]struct{}, len(deployedContracts))
+	for addr := range deployedContracts {
+		initialContractsSet[addr] = struct{}{}
+	}
+	coverageTracer.SetInitialContractsSet(&initialContractsSet)
+
 	// Set our coverage maps to those collected when replaying all blocks when cloning.
 	c.coverageMaps = coverage.NewCoverageMaps()
 	for _, block := range testChain.CommittedBlocks() {

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -595,6 +595,12 @@ func (fw *FuzzerWorker) run(baseTestChain *chain.TestChain) (bool, error) {
 		return nil
 	})
 
+	initialContractsSet := make(map[common.Address]struct{}, len(fw.deployedContracts))
+	for addr := range fw.deployedContracts {
+		initialContractsSet[addr] = struct{}{}
+	}
+	fw.coverageTracer.SetInitialContractsSet(&initialContractsSet)
+
 	// If we encountered an error during cloning, return it.
 	if err != nil {
 		return false, err

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -595,6 +595,8 @@ func (fw *FuzzerWorker) run(baseTestChain *chain.TestChain) (bool, error) {
 		return nil
 	})
 
+	// Freeze a set of `fw.deployedContracts`'s keys so that we have a set of addresses present in baseTestChain.
+	// Feed this set to the coverage tracer.
 	initialContractsSet := make(map[common.Address]struct{}, len(fw.deployedContracts))
 	for addr := range fw.deployedContracts {
 		initialContractsSet[addr] = struct{}{}


### PR DESCRIPTION
Otherwise we could have the corpus keep expanding infinitely if new contracts get deployed at arbitrary addresses during runtime, leading to OOM