### PR TITLE
Add external library support

### DIFF
--- a/compilation/platforms/crytic_compile.go
+++ b/compilation/platforms/crytic_compile.go
@@ -1,7 +1,6 @@
 package platforms
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -241,6 +240,7 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 			}
 
 			// Decode our init and runtime bytecode
+			/***
 			initBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.Bin, "0x"))
 			if err != nil {
 				return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'\n", contractName)
@@ -248,16 +248,17 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 			runtimeBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.BinRuntime, "0x"))
 			if err != nil {
 				return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'\n", contractName)
-			}
+			}**/
 
 			// Add contract details
 			compilation.SourcePathToArtifact[sourcePath].Contracts[contractName] = types.CompiledContract{
-				Abi:             *contractAbi,
-				InitBytecode:    initBytecode,
-				RuntimeBytecode: runtimeBytecode,
-				SrcMapsInit:     contract.SrcMap,
-				SrcMapsRuntime:  contract.SrcMapRuntime,
-				Kind:            contractKinds[contractName],
+				Abi:                 *contractAbi,
+				InitBytecode:        []byte(contract.Bin),
+				RuntimeBytecode:     []byte(contract.BinRuntime),
+				SrcMapsInit:         contract.SrcMap,
+				SrcMapsRuntime:      contract.SrcMapRuntime,
+				Kind:                contractKinds[contractName],
+				LibraryPlaceholders: types.ParseBytecodeForPlaceholders(contract.BinRuntime),
 			}
 		}
 

--- a/compilation/platforms/crytic_compile.go
+++ b/compilation/platforms/crytic_compile.go
@@ -247,7 +247,7 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 				SrcMapsInit:         contract.SrcMap,
 				SrcMapsRuntime:      contract.SrcMapRuntime,
 				Kind:                contractKinds[contractName],
-				LibraryPlaceholders: types.ParseBytecodeForPlaceholders(contract.BinRuntime),
+				LibraryPlaceholders: types.ParseBytecodeForPlaceholders(contract.Bin),
 			}
 		}
 

--- a/compilation/platforms/crytic_compile.go
+++ b/compilation/platforms/crytic_compile.go
@@ -239,18 +239,6 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 				return nil, "", fmt.Errorf("unable to parse ABI for contract '%s'\n", contractName)
 			}
 
-			// Decode our init and runtime bytecode
-
-			/*
-				initBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.Bin, "0x"))
-				if err != nil {
-					return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'\n", contractName)
-				}
-				runtimeBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.BinRuntime, "0x"))
-				if err != nil {
-					return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'\n", contractName)
-				}*/
-
 			// Add contract details
 			compilation.SourcePathToArtifact[sourcePath].Contracts[contractName] = types.CompiledContract{
 				Abi:                 *contractAbi,

--- a/compilation/platforms/crytic_compile.go
+++ b/compilation/platforms/crytic_compile.go
@@ -240,15 +240,16 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 			}
 
 			// Decode our init and runtime bytecode
-			/***
-			initBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.Bin, "0x"))
-			if err != nil {
-				return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'\n", contractName)
-			}
-			runtimeBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.BinRuntime, "0x"))
-			if err != nil {
-				return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'\n", contractName)
-			}**/
+
+			/*
+				initBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.Bin, "0x"))
+				if err != nil {
+					return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'\n", contractName)
+				}
+				runtimeBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.BinRuntime, "0x"))
+				if err != nil {
+					return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'\n", contractName)
+				}*/
 
 			// Add contract details
 			compilation.SourcePathToArtifact[sourcePath].Contracts[contractName] = types.CompiledContract{

--- a/compilation/platforms/solc.go
+++ b/compilation/platforms/solc.go
@@ -1,7 +1,6 @@
 package platforms
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -178,23 +177,25 @@ func (s *SolcCompilationConfig) Compile() ([]types.Compilation, string, error) {
 		}
 
 		// Decode our init and runtime bytecode
-		initBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.Code, "0x"))
-		if err != nil {
-			return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'\n", contractName)
-		}
-		runtimeBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.RuntimeCode, "0x"))
-		if err != nil {
-			return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'\n", contractName)
-		}
+		/*
+			initBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.Code, "0x"))
+			if err != nil {
+				return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'\n", contractName)
+			}
+			runtimeBytecode, err := hex.DecodeString(strings.TrimPrefix(contract.RuntimeCode, "0x"))
+			if err != nil {
+				return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'\n", contractName)
+			}*/
 
 		// Construct our compiled contract
 		compilation.SourcePathToArtifact[sourcePath].Contracts[contractName] = types.CompiledContract{
-			Abi:             *contractAbi,
-			InitBytecode:    initBytecode,
-			RuntimeBytecode: runtimeBytecode,
-			SrcMapsInit:     contract.Info.SrcMap.(string),
-			SrcMapsRuntime:  contract.Info.SrcMapRuntime,
-			Kind:            contractKinds[contractName],
+			Abi:                 *contractAbi,
+			InitBytecode:        []byte(contract.Code),
+			RuntimeBytecode:     []byte(contract.RuntimeCode),
+			SrcMapsInit:         contract.Info.SrcMap.(string),
+			SrcMapsRuntime:      contract.Info.SrcMapRuntime,
+			Kind:                contractKinds[contractName],
+			LibraryPlaceholders: types.ParseBytecodeForPlaceholders(contract.RuntimeCode),
 		}
 	}
 

--- a/compilation/platforms/solc.go
+++ b/compilation/platforms/solc.go
@@ -195,7 +195,7 @@ func (s *SolcCompilationConfig) Compile() ([]types.Compilation, string, error) {
 			SrcMapsInit:         contract.Info.SrcMap.(string),
 			SrcMapsRuntime:      contract.Info.SrcMapRuntime,
 			Kind:                contractKinds[contractName],
-			LibraryPlaceholders: types.ParseBytecodeForPlaceholders(contract.RuntimeCode),
+			LibraryPlaceholders: types.ParseBytecodeForPlaceholders(contract.Code),
 		}
 	}
 

--- a/compilation/types/compiled_contract.go
+++ b/compilation/types/compiled_contract.go
@@ -136,11 +136,7 @@ func (c *CompiledContract) RuntimeBytecodeBytes() ([]byte, error) {
 // argument data to use.
 func (c *CompiledContract) GetDeploymentMessageData(args []any) ([]byte, error) {
 	// ABI encode constructor arguments and append them to the end of the bytecode
-	initBytecode, err := c.InitBytecodeBytes()
-	if err != nil {
-		return nil, fmt.Errorf("could not decode InitBytecode due to error: %v", err)
-	}
-	initBytecodeWithArgs := slices.Clone(initBytecode)
+	initBytecodeWithArgs := slices.Clone(c.InitBytecode)
 	if len(c.Abi.Constructor.Inputs) > 0 {
 		data, err := c.Abi.Pack("", args...)
 		if err != nil {
@@ -180,6 +176,11 @@ func ParseBytecodeForPlaceholders(bytecode string) map[string]any {
 // ReplacePlaceholdersInBytecode replaces library placeholders in bytecode with actual library addresses
 func (c *CompiledContract) ReplacePlaceholdersInBytecode(deployedLibraries map[string]common.Address) {
 	if len(c.LibraryPlaceholders) == 0 || len(c.InitBytecode) == 0 {
+		initBytecode, err := c.InitBytecodeBytes()
+		if err != nil {
+			panic(fmt.Errorf("unable to parse init bytecode for contract \n"))
+		}
+		c.InitBytecode = initBytecode
 		return
 	}
 
@@ -217,4 +218,10 @@ func (c *CompiledContract) ReplacePlaceholdersInBytecode(deployedLibraries map[s
 
 	// Update the bytecode
 	c.InitBytecode = []byte(bytecodeHex)
+	initBytecode, err := c.InitBytecodeBytes()
+	if err != nil {
+		panic(fmt.Errorf("unable to parse init bytecode for contract \n"))
+	}
+	c.InitBytecode = initBytecode
+
 }

--- a/compilation/types/library_utils.go
+++ b/compilation/types/library_utils.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"encoding/hex"
+	"github.com/crytic/medusa-geth/crypto"
+	"path/filepath"
+)
+
+// GenerateLibraryPlaceholder creates a library placeholder based on the keccak256 hash
+// of the fully qualified library name according to Solidity's algorithm
+func GenerateLibraryPlaceholder(fullyQualifiedName string) string {
+	// Calculate keccak256 hash of the library name
+	hash := crypto.Keccak256Hash([]byte(fullyQualifiedName))
+
+	// Take the first 34 characters of the hash (17 bytes)
+	hashStr := hex.EncodeToString(hash.Bytes())
+	placeholderHash := hashStr[:34]
+
+	// Format according to Solidity's placeholder format: __$<hash>$__
+	return placeholderHash
+}
+
+// MapPlaceholdersToLibraries generates a mapping of placeholders to library names
+// by computing the keccak256 hash of each library's fully qualified name
+func MapPlaceholdersToLibraries(placeholderToLibrary map[string]any, availableLibraries map[string]string) {
+
+	// For each library, calculate its expected placeholder and check if it's in the bytecode
+	for fullName, shortName := range availableLibraries {
+		placeholder := GenerateLibraryPlaceholder(fullName)
+
+		// Check if this placeholder exists in the bytecode
+		for p := range placeholderToLibrary {
+			if p == placeholder {
+				placeholderToLibrary[placeholder] = shortName
+				break
+			}
+		}
+	}
+}
+
+// GetAvailableLibraries builds a map of full library names to short names
+// from the compilation results
+func GetAvailableLibraries(compilations []Compilation) (map[string]string, string) {
+	libraryMap := make(map[string]string)
+
+	// Process each compilation unit
+	for _, compilation := range compilations {
+		// Go through each source file
+		for sourcePath, sourceArtifact := range compilation.SourcePathToArtifact {
+			// Check each contract in the source
+			for contractName, contract := range sourceArtifact.Contracts {
+				// Check if this is a library
+				if contract.Kind == ContractKindLibrary {
+					// Full name is "sourcePath:contractName"
+					libPath := filepath.Join(filepath.Base(filepath.Dir(sourcePath)), filepath.Base(sourcePath))
+					fullName := libPath + ":" + contractName
+					// Short name is just the contract name
+					shortName := contractName
+					libraryMap[fullName] = shortName
+				}
+			}
+		}
+	}
+	return libraryMap, ""
+}

--- a/compilation/types/library_utils.go
+++ b/compilation/types/library_utils.go
@@ -3,7 +3,6 @@ package types
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/crytic/medusa-geth/common"
 	"github.com/crytic/medusa-geth/crypto"
 	"path/filepath"
 )
@@ -64,58 +63,6 @@ func GetAvailableLibraries(compilations []Compilation) (map[string]string, strin
 		}
 	}
 	return libraryMap, ""
-}
-
-// ReplacePlaceholdersInBytecode replaces library placeholders in bytecode with actual library addresses
-func ReplacePlaceholdersInBytecode(bytecode []byte, libraryPlaceholders map[string]any, deployedLibraries map[string]common.Address) []byte {
-	// Clone the bytecode to avoid modifying the original
-	result := make([]byte, len(bytecode))
-	copy(result, bytecode)
-
-	// For each library placeholder
-	for placeholder, libNameAny := range libraryPlaceholders {
-		libName, ok := libNameAny.(string)
-		if !ok || libName == "" {
-			continue
-		}
-
-		// Get the deployed library address
-		libraryAddr, exists := deployedLibraries[libName]
-		if !exists {
-			continue
-		}
-
-		// Find the placeholder pattern in the bytecode
-		// The full pattern in bytecode is: __$<placeholder>$__
-		fullPattern := fmt.Sprintf("__%s__", placeholder)
-
-		// Replace all occurrences in the bytecode
-		// Since we're working with bytes, we need to do this manually
-		for i := 0; i <= len(result)-len(fullPattern); i++ {
-			match := true
-			for j := 0; j < len(fullPattern); j++ {
-				if i+j >= len(result) || result[i+j] != fullPattern[j] {
-					match = false
-					break
-				}
-			}
-
-			if match {
-				// Replace the placeholder with the address (padded)
-				// The address needs to be exactly the same length as the placeholder
-				addrBytes := libraryAddr.Bytes()
-				for j := 0; j < len(addrBytes) && j < len(fullPattern); j++ {
-					result[i+j] = addrBytes[j]
-				}
-				// Pad remaining bytes with zeros if needed
-				for j := len(addrBytes); j < len(fullPattern); j++ {
-					result[i+j] = 0
-				}
-			}
-		}
-	}
-
-	return result
 }
 
 // GetDeploymentOrder returns a topologically sorted list of libraries/contracts

--- a/fuzzing/config/config_defaults.go
+++ b/fuzzing/config/config_defaults.go
@@ -67,7 +67,7 @@ func GetDefaultProjectConfig(platform string) (*ProjectConfig, error) {
 				StopOnFailedTest:             true,
 				StopOnFailedContractMatching: false,
 				StopOnNoTests:                true,
-				TestViewMethods:              false,
+				TestViewMethods:              true,
 				TestAllContracts:             false,
 				Verbosity:                    1,
 				TargetFunctionSignatures:     []string{},

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -109,6 +109,7 @@ type Fuzzer struct {
 	// It takes a decent amount of time to calculate, so we only log once a minute,
 	// and only when debug logging is enabled.
 	lastPCsLogMsg time.Time
+	libraryMap    map[string]string
 }
 
 // Amount of time between "total PCs hit" log messages. This message is only output when debug logging is enabled.
@@ -210,6 +211,9 @@ func NewFuzzer(config config.ProjectConfig) (*Fuzzer, error) {
 			fuzzer.logger.Error("Failed to compile target", err)
 			return nil, err
 		}
+
+		allLibraries, _ := compilationTypes.GetAvailableLibraries(compilations)
+		fuzzer.libraryMap = allLibraries
 		fuzzer.logger.Info("Finished compiling targets in ", time.Since(start).Round(time.Second))
 
 		// Add our compilation targets
@@ -366,6 +370,7 @@ func (f *Fuzzer) AddCompilationTargets(compilations []compilationTypes.Compilati
 					continue
 				}
 
+				compilationTypes.MapPlaceholdersToLibraries(contract.LibraryPlaceholders, f.libraryMap)
 				contractDefinition := fuzzerTypes.NewContract(contractName, sourcePath, &contract, compilation)
 
 				// Sort available methods by type

--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -613,17 +613,12 @@ func chainSetupFromCompilations(fuzzer *Fuzzer, testChain *chain.TestChain) (*ex
 
 func (f *Fuzzer) deployContract(testChain *chain.TestChain, contract *fuzzerTypes.Contract, args []any, contractBalance *big.Int, deployedContracts map[string]common.Address) (any, error) {
 	contractName := contract.Name()
+	contract.CompiledContract().ReplacePlaceholdersInBytecode(deployedContracts)
+
 	// Construct our deployment message/tx data field
 	msgData, err := contract.CompiledContract().GetDeploymentMessageData(args)
 	if err != nil {
 		return nil, fmt.Errorf("initial contract deployment failed for contract \"%v\", error: %v", contractName, err)
-	}
-
-	// If this contract has library dependencies, replace placeholders in the bytecode
-	if len(contract.CompiledContract().LibraryPlaceholders) > 0 {
-		// Replace library placeholders with deployed library addresses
-		replacedMsgData := compilationTypes.ReplacePlaceholdersInBytecode(msgData, contract.CompiledContract().LibraryPlaceholders, deployedContracts)
-		msgData = replacedMsgData
 	}
 
 	// Create a message to represent our contract deployment (we let deployments consume the whole block

--- a/fuzzing/testdata/contracts/external_library/external_library.sol
+++ b/fuzzing/testdata/contracts/external_library/external_library.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title Library1
+ * @dev A basic library that demonstrates a simple public function returning a string.
+ */
+library Library1 {
+    /**
+     * @dev Returns a static string "Library"
+     * @return A static string value
+     */
+    function getLibrary() public pure returns(string memory) {
+        return "Library";
+    }
+}
+
+/**
+ * @title Library2
+ * @dev A library that depends on Library1, demonstrating direct library dependencies.
+ * This library calls Library1's function and returns its result.
+ */
+library Library2 {
+    /**
+     * @dev Calls and returns the result from Library1.getLibrary()
+     * @return A string value from the dependent library
+     */
+    function getLibrary() public pure returns(string memory) {
+        return Library1.getLibrary();
+    }
+}
+
+/**
+ * @title Library3
+ * @dev A library with multiple dependencies, demonstrating complex dependency chains.
+ * This library calls both Library1 and Library2, creating a transitive dependency.
+ */
+library Library3 {
+    /**
+     * @dev Calls Library2.getLibrary() and then returns the result from Library1.getLibrary()
+     * @return A string value from Library1
+     */
+    function getLibrary() public pure returns(string memory) {
+        Library2.getLibrary();
+        return Library1.getLibrary();
+    }
+}
+
+/**
+ * @title TestExternalLibrary
+ * @dev A contract that uses the external libraries defined above.
+ * This contract serves as a test case for the Medusa fuzzer to verify proper
+ * library resolution, deployment ordering, and ABI handling.
+ */
+contract TestExternalLibrary {
+    /**
+     * @dev A function designed to be targeted by the fuzzer
+     * Contains a deliberate assertion failure when Library3 returns "Library"
+     * @return false this line never gets executed
+     * @notice This function is used to test if the fuzzer can properly resolve
+     * library dependencies
+     */
+    function fuzz_me() public returns(bool){
+       if (keccak256(abi.encodePacked(Library3.getLibrary())) == keccak256(abi.encodePacked("Library"))) {
+            assert(false);
+            return false;
+       }
+    }
+}


### PR DESCRIPTION
``Overview``

This PR adds support for external libraries in Medusa, allowing for proper deployment, linking, and testing of contracts that depend on external Solidity libraries.

``Key Changes``

  - Added infrastructure to identify and map library dependencies between contracts
  - Implemented topological sorting algorithm for determining correct deployment order
  - Created bytecode linking functionality to replace library placeholders with deployed addresses
  - Updated test chain deployment process to respect library dependency order

  ``Testing``

  - Added test contracts in `fuzzing/testdata/contracts/external_library/` demonstrating various library dependency scenarios
  - Test contracts include multi-level dependencies (libraries depending on other libraries)
  - Tests validate correct library deployment order and proper function execution through dependencies