### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -255,10 +256,8 @@ func (testCfg *TestingConfig) Validate() error {
 
 	// Validate that prefixes do not overlap
 	for _, prefix := range testCfg.PropertyTesting.TestPrefixes {
-		for _, prefix2 := range testCfg.OptimizationTesting.TestPrefixes {
-			if prefix == prefix2 {
-				return errors.New("project configuration must specify unique test name prefixes for property and optimization testing")
-			}
+		if slices.Contains(testCfg.OptimizationTesting.TestPrefixes, prefix) {
+			return errors.New("project configuration must specify unique test name prefixes for property and optimization testing")
 		}
 	}
 

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -5,6 +5,7 @@ import (
 	"github.com/crytic/medusa/logging/colors"
 	"github.com/rs/zerolog"
 	"io"
+	"slices"
 	"strings"
 )
 
@@ -103,11 +104,9 @@ func (l *Logger) NewSubLogger(key string, value string) *Logger {
 func (l *Logger) AddWriter(writer io.Writer, format LogFormat, colored bool) {
 	// First, try to add the writer to the list of channels that want structured logs
 	if format == STRUCTURED {
-		for _, w := range l.structuredWriters {
-			if w == writer {
-				// Writer already exists, return
-				return
-			}
+		if slices.Contains(l.structuredWriters, writer) {
+			// Writer already exists, return
+			return
 		}
 		// Add the writer and recreate the logger
 		l.structuredWriters = append(l.structuredWriters, writer)


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.