### PR TITLE
Error check on NewTestChain call

### DIFF
--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -493,10 +493,13 @@ func (f *Fuzzer) createTestChain() (*chain.TestChain, error) {
 
 	// Create our test chain with our basic allocations and passed medusa's chain configuration
 	testChain, err := chain.NewTestChain(f.ctx, genesisAlloc, &f.config.Fuzzing.TestChainConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	// Set our block gas limit
 	testChain.BlockGasLimit = blockGasLimit
-	return testChain, err
+	return testChain, nil
 }
 
 // chainSetupFromCompilations is a TestChainSetupFunc which sets up the base test chain state by deploying


### PR DESCRIPTION
Gets rid of the panic from #635 , now it exits cleanly with an error message instead:
```
samalws@Sams-MacBook-Pro medusa-rpc-crash-repro % ../medusa/medusa fuzz
⇾ Reading the configuration file at: /Users/samalws/Documents/medusa-july-2025/635/medusa-rpc-crash-repro/medusa.json
⇾ Compiling targets with crytic-compile
⇾ Running command:
/Users/samalws/Library/Python/3.9/bin/crytic-compile . --export-format solc --foundry-compile-all
⇾ Finished compiling targets in 2s
⇾ Using cached Slither results found at slither_results.json
⇾ Initializing corpus
error Failed to create the test chain
‣ could not open db: timeout

```