### PR TITLE
feat. address trimming matches solidity address 0

### DIFF
--- a/utils/address_utils.go
+++ b/utils/address_utils.go
@@ -65,8 +65,16 @@ func TrimLeadingZeroesFromAddress(address common.Address) string {
 	hexString := address.String()
 	if strings.HasPrefix(hexString, "0x") {
 		// Retain "0x" and trim leading zeroes from the rest of the string
-		return "0x" + strings.TrimLeft(hexString[2:], "0")
+		trimmed := strings.TrimLeft(hexString[2:], "0")
+		if trimmed == "" {
+			return "0x0"
+		}
+		return "0x" + trimmed
 	}
 	// Trim leading zeroes if there's no "0x" prefix
-	return strings.TrimLeft(hexString, "0")
+	trimmed := strings.TrimLeft(hexString, "0")
+	if trimmed == "" {
+		return "0"
+	}
+	return trimmed
 }


### PR DESCRIPTION
Introduces a small change to make address(0) be a valid address for Solidity.

By leaving one `0` solidity can recognize the address as valid, we use this for scraping the logs but this should be useful for other tools as well

Before:
<img width="1132" height="148" alt="Screenshot 2025-08-21 at 17 19 35" src="https://github.com/user-attachments/assets/24a58dd5-3219-49f8-bbdf-1bd7342e9e52" />

After:
<img width="1131" height="160" alt="Screenshot 2025-08-21 at 17 18 59" src="https://github.com/user-attachments/assets/6ef9a789-1f70-48d6-a6eb-67759e246297" />