### PR TITLE
Fix events collection

### DIFF
--- a/fuzzing/executiontracer/execution_tracer.go
+++ b/fuzzing/executiontracer/execution_tracer.go
@@ -73,6 +73,9 @@ type ExecutionTracer struct {
 
 	// verbosity describes the verbosity level that will be used for the execution trace
 	verbosity config.VerbosityLevel
+
+	// currentTxHash stores the hash of the current transaction being traced
+	currentTxHash common.Hash
 }
 
 // NewExecutionTracer creates a ExecutionTracer and returns it.
@@ -136,6 +139,9 @@ func (t *ExecutionTracer) OnTxStart(vm *tracing.VMContext, tx *coretypes.Transac
 
 	// Store our evm reference
 	t.evmContext = vm
+
+	// Store the current transaction hash
+	t.currentTxHash = tx.Hash()
 }
 
 // resolveCallFrameConstructorArgs resolves previously unresolved constructor argument ABI data from the call data, if
@@ -309,7 +315,9 @@ func (t *ExecutionTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope t
 	// TODO: Move this to OnLog
 	if op == byte(vm.LOG0) || op == byte(vm.LOG1) || op == byte(vm.LOG2) || op == byte(vm.LOG3) || op == byte(vm.LOG4) {
 		t.onNextCaptureState = append(t.onNextCaptureState, func() {
-			logs := t.evmContext.StateDB.(types.MedusaStateDB).Logs()
+			blockNumber := t.evmContext.BlockNumber.Uint64()
+			blockHash, _ := t.testChain.BlockHashFromNumber(blockNumber)
+			logs := t.evmContext.StateDB.(types.MedusaStateDB).GetLogs(t.currentTxHash, blockNumber, blockHash)
 			if len(logs) > 0 {
 				t.currentCallFrame.Operations = append(t.currentCallFrame.Operations, logs[len(logs)-1])
 			}

--- a/utils/message_transaction_utils.go
+++ b/utils/message_transaction_utils.go
@@ -14,5 +14,9 @@ func MessageToTransaction(msg *core.Message) *types.Transaction {
 		To:       msg.To,
 		Value:    msg.Value,
 		Data:     msg.Data,
+		// HACK: to avoid transactions from different senders hashing to
+		// the same Hash() / receipt, we stuff the From address on one of
+		// the signature parameters
+		S: msg.From.Big(),
 	})
 }


### PR DESCRIPTION
GetLogs() walks the `map[common.Hash][]*types.Log` and concatenates all of the events there. Then it picks the last one. However, the current tx hash is not necessarily the last one on the concatenation, which means that the event collected is probably not the desired one.

This changes the code to store the current tx hash OnTxStart and then use it to query the specific logs for that transaction.

Additionally, the transaction object doesn't have the "from" address as that is implied by the signature on a normal transaction. However, medusa does not sign transactions, which causes transaction hashes to collision if they only differ in the sender address. To keep them distinguishable from each other, this stores the from address in one of the signature fields.