### PR TITLE
add USE_FULL_BYTECODE env var

### DIFF
--- a/fuzzing/coverage/source_analysis.go
+++ b/fuzzing/coverage/source_analysis.go
@@ -506,21 +506,22 @@ func determineLinesCovered(cm *ContractCoverageMap, bytecode []byte, logger *log
 		// Test some conditions that should always hold...
 		op := vm.OpCode(bytecode[pc])                                                         // Used only for checks below
 		isJumpOrReturn := op == vm.JUMP || op == vm.JUMPI || op == vm.RETURN || op == vm.STOP // Used only for checks below
+		warningMsgFormat := "WARNING: %s. The coverage report will be inaccurate. Try setting USE_FULL_BYTECODE=1 in your environment and rerunning medusa. If that doesn't make this message go away, you found a bug; please report it at https://github.com/crytic/medusa/issues. Debug info: hit: %d, enterCount: %d, revertCount: %d, allLeaveCount: %d, idx: %d, pc: %d, op: %v, isJumpOrReturn: %t, len(bytecode): %d, len(indexToOffset): %d.\n"
 		if hit+enterCount < hit {
-			logger.Warn(fmt.Sprintf("WARNING: Overflow while generating coverage report, during `hit += enterCount` calculation. The coverage report will be inaccurate. This is a bug; please report it at https://github.com/crytic/medusa/issues. Debug info: hit: %d, enterCount: %d, revertCount: %d, allLeaveCount: %d, idx: %d, pc: %d, op: %d, isJumpOrReturn: %t, len(bytecode): %d, len(indexToOffset): %d.\n", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
+			logger.Warn(fmt.Sprintf(warningMsgFormat, "Overflow while generating coverage report, during `hit += enterCount` calculation", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
 		}
 		if hit+enterCount < revertCount {
-			logger.Warn(fmt.Sprintf("WARNING: Underflow while generating coverage report, during `hit - revertCount` calculation. The coverage report will be inaccurate. This is a bug; please report it at https://github.com/crytic/medusa/issues. Debug info: hit: %d, enterCount: %d, revertCount: %d, allLeaveCount: %d, idx: %d, pc: %d, op: %d, isJumpOrReturn: %t, len(bytecode): %d, len(indexToOffset): %d.\n", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
+			logger.Warn(fmt.Sprintf(warningMsgFormat, "Underflow while generating coverage report, during `hit - revertCount` calculation", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
 		}
 		if hit+enterCount < allLeaveCount {
-			logger.Warn(fmt.Sprintf("WARNING: Underflow while generating coverage report, during `hit -= allLeaveCount` calculation. The coverage report will be inaccurate. This is a bug; please report it at https://github.com/crytic/medusa/issues. Debug info: hit: %d, enterCount: %d, revertCount: %d, allLeaveCount: %d, idx: %d, pc: %d, op: %d, isJumpOrReturn: %t, len(bytecode): %d, len(indexToOffset): %d.\n", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
+			logger.Warn(fmt.Sprintf(warningMsgFormat, "Underflow while generating coverage report, during `hit -= allLeaveCount` calculation", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
 		}
 		if isJumpOrReturn && hit+enterCount != allLeaveCount {
-			logger.Warn(fmt.Sprintf("WARNING: Unexpected condition while generating coverage report: return or jump does not reset hit count to 0. The coverage report will be inaccurate. This is a bug; please report it at https://github.com/crytic/medusa/issues. Debug info: hit: %d, enterCount: %d, revertCount: %d, allLeaveCount: %d, idx: %d, pc: %d, op: %d, isJumpOrReturn: %t, len(bytecode): %d, len(indexToOffset): %d.\n", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
+			logger.Warn(fmt.Sprintf(warningMsgFormat, "Unexpected condition while generating coverage report: return or jump does not reset hit count to 0", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
 		}
 		if allLeaveCount-revertCount > 0 && hit+enterCount != allLeaveCount {
 			// The check is allLeaveCount-revertCount > 0 rather than just allLeaveCount > 0 since reverts don't have to reset hit to 0
-			logger.Warn(fmt.Sprintf("WARNING: Unexpected condition while generating coverage report: positive allLeaveCount does not reset hit count to 0. The coverage report will be inaccurate. This is a bug; please report it at https://github.com/crytic/medusa/issues. Debug info: hit: %d, enterCount: %d, revertCount: %d, allLeaveCount: %d, idx: %d, pc: %d, op: %d, isJumpOrReturn: %t, len(bytecode): %d, len(indexToOffset): %d.\n", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
+			logger.Warn(fmt.Sprintf(warningMsgFormat, "Unexpected condition while generating coverage report: positive allLeaveCount does not reset hit count to 0", hit, enterCount, revertCount, allLeaveCount, idx, pc, op, isJumpOrReturn, len(bytecode), len(indexToOffset)))
 		}
 
 		// Modify hit based on coverage for this line, and record results
@@ -530,7 +531,7 @@ func determineLinesCovered(cm *ContractCoverageMap, bytecode []byte, logger *log
 		hit -= allLeaveCount
 	}
 	if hit != 0 {
-		logger.Warn(fmt.Sprintf("WARNING: Nonzero final hit count. The coverage report will be inaccurate. This is a bug; please report it at https://github.com/crytic/medusa/issues. Debug info: hit: %d, len(bytecode): %d, len(indexToOffset): %d.\n", hit, len(bytecode), len(indexToOffset)))
+		logger.Warn(fmt.Sprintf("WARNING: Nonzero final hit count. The coverage report will be inaccurate. Try setting USE_FULL_BYTECODE=1 in your environment and rerunning medusa. If that doesn't make this message go away, you found a bug; please report it at https://github.com/crytic/medusa/issues. Debug info: hit: %d, len(bytecode): %d, len(indexToOffset): %d.\n", hit, len(bytecode), len(indexToOffset)))
 	}
 
 	return successfulHits, revertedHits


### PR DESCRIPTION
Resolves #686 
Adds an environment variable that can make getContractCoverageMapHash read the full bytecode rather than just the metadata