### PR TITLE
fuzzing: improve error handling in BuildLibraryNameMapping

### DIFF
--- a/fuzzing/utils/library_utils.go
+++ b/fuzzing/utils/library_utils.go
@@ -61,14 +61,15 @@ func BuildLibraryNameMapping(compilations []types.Compilation) map[string]string
 					}
 				}
 			}
-			// Throw error if for any reason libPath becomes empty
-			if libPath == "" {
-				panic("libPath is empty, could not determine the library path")
-			}
+
 			// Check each contract in the source
 			for contractName, contract := range sourceArtifact.Contracts {
 				// Check if this is a library
 				if contract.Kind == types.ContractKindLibrary {
+					// Throw an error if for any reason libPath becomes empty. We need an absolute path.
+					if libPath == "" {
+						panic(fmt.Sprintf("cannot resolve fully qualified path for library %s", contractName))
+					}
 					fullName := libPath + ":" + contractName
 					// Short name is just the contract name
 					shortName := contractName


### PR DESCRIPTION
## Summary

This PR fixes overly strict error handling in `BuildLibraryNameMapping` that would panic for all source files if `absolutePath` could not be extracted from the AST.

## Problem

The previous implementation would panic if any source file's AST didn't have an extractable `absolutePath`. This was problematic because:

1. **AST can be nil**: In `crytic_compile.go:231`, parent source artifacts are explicitly created with `Ast: nil`
2. **Only libraries need this mapping**: The fully qualified path is only required for library linking, not for regular contracts or interfaces
3. **Silent failures**: When `libPath` was empty, malformed entries like `":LibraryName"` would be created instead of `"path/to/File.sol:LibraryName"`, breaking library linking without clear error messages

## Solution

This PR moves the panic inside the library-checking conditional (after the `contract.Kind == types.ContractKindLibrary` check) so it only triggers when we cannot resolve the path for an actual library. The changes:

- Allow non-library source files to gracefully handle missing/nil ASTs
- Ensure library linking failures are caught early with a descriptive error message
- Improved error message that includes the library name: `"cannot resolve fully qualified path for library {name}"`

## Testing

The fix allows the fuzzer to process source files with nil ASTs or missing `absolutePath` fields, while still catching cases where libraries cannot be properly resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)