### PR TITLE
Fix Docker installation instructions to use GHCR

### DIFF
--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -92,16 +92,16 @@ You need to have Docker installed. Installation instructions for Docker can be f
 
 ### Using the Docker image
 
-Pull the latest Docker image:
+Pull the latest Docker image from GitHub Container Registry:
 
 ```shell
-docker pull crytic/medusa
+docker pull ghcr.io/crytic/medusa
 ```
 
 Run medusa in a container:
 
 ```shell
-docker run -it --rm -v $(pwd):/src crytic/medusa <command>
+docker run -it --rm -v $(pwd):/src ghcr.io/crytic/medusa <command>
 ```
 
 This will mount your current directory to `/src` in the container and run the specified medusa command.


### PR DESCRIPTION
## Summary

Fixes #613 by updating Docker installation instructions to use the correct GitHub Container Registry (GHCR) image path.

## Changes

Updated `docs/src/getting_started/installation.md`:
- Changed `docker pull crytic/medusa` → `docker pull ghcr.io/crytic/medusa`
- Changed `docker run ... crytic/medusa` → `docker run ... ghcr.io/crytic/medusa`
- Added clarification that the image is hosted on GitHub Container Registry

## Issue

The previous instructions referenced `crytic/medusa` which is the Docker Hub format, but medusa images are actually hosted on GitHub Container Registry at `ghcr.io/crytic/medusa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)