### PR TITLE
ci: optimize CI speed with parallel builds, caching, and uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,11 +207,6 @@ jobs:
           printf 'TEMP=%s\\tmpdir\n' "$DIR" | tee -a "$GITHUB_ENV"
           go env
           echo "::endgroup::"
-          echo "::group::Python"
-          python3 -m venv venv
-          printf '%s\\venv\\Scripts\n' "$DIR" | tee -a "$GITHUB_PATH"
-          printf 'VIRTUAL_ENV=%s\\venv\n' "$DIR" | tee -a "$GITHUB_ENV"
-          echo "::endgroup::"
           echo "::group::Node"
           npm config set cache "$DIR\\npm-cache" --global
           echo "::endgroup::"
@@ -240,6 +235,12 @@ jobs:
 
           # Wait for all
           wait $UV_PID1 $UV_PID2 $UV_PID3 $NPM_PID
+
+      - name: Cache solc
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.solc-select/artifacts
+          key: solc-0.8.28-${{ runner.os }}
 
       - name: Install solc
         run: |


### PR DESCRIPTION
## Summary

- Run builds in parallel with lint instead of waiting for tests to complete
- Consolidate from 4 to 3 platforms (ubuntu-latest, macos-26, windows-latest)
- Add aggressive caching: golangci-lint-action, actionlint binary, npm cache
- Replace pip with uv (10-100x faster) for Python package installation
- Parallelize Python and Node dependency installation in test job

## Expected Improvement

| Metric | Before | After |
|--------|--------|-------|
| Build dependency | lint + test | lint only |
| Platforms | 4 | 3 |
| Python installer | pip | uv |
| Tool caching | none | golangci-lint, actionlint, npm |
| Est. runtime | ~10-12 min | ~5-7 min |

## Test plan

- [ ] Verify all 3 platforms build successfully
- [ ] Verify all 3 platforms pass tests
- [ ] Verify macos-26 runner works (preview status)
- [ ] Check cache hit rates in action logs
- [ ] Compare CI runtime against previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)