### PR TITLE
ci: add pre-commit hooks with prek for code quality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+  - repo: local
+    hooks:
+      - id: goimports
+        name: goimports
+        entry: bash -c 'goimports -w $(find . -name "*.go" -not -path "./vendor/*") && git diff --exit-code'
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: go-fmt
+        name: go fmt
+        entry: bash -c 'go fmt ./... && git diff --exit-code'
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: golangci-lint
+        name: golangci-lint
+        entry: golangci-lint run --timeout 5m
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: dprint
+        name: dprint
+        entry: dprint check
+        language: system
+        types_or: [markdown, yaml, json]
+
+      - id: actionlint
+        name: actionlint
+        entry: actionlint
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,15 +23,21 @@ Medusa is a cross-platform smart contract fuzzer written in Go, built on go-ethe
 
 ### Lint & Format
 
+- `goimports -w .` - Format imports and code (groups stdlib, external, local)
 - `go fmt ./...` - Format Go code (required before commits)
 - `golangci-lint run --timeout 5m` - Run comprehensive lint checks (mirrors CI)
-- `prettier '**/*.md' '**/*.yml' '**/*.json' -w` - Format markdown, YAML, and JSON files
+- `dprint fmt` - Format markdown, YAML, and JSON files
 - `actionlint` - Lint GitHub Actions workflow files
 
 ### Run
 
 - `go run . --config path/to/config.yaml` - Compile and run the fuzzer
 - `nix develop` - Enter the pinned Nix development shell with all dependencies
+
+### Git Hooks
+
+- `prek install` - Install pre-commit hooks (run once after cloning)
+- `prek run` - Manually run all pre-commit checks (use within `nix develop` shell)
 
 ## Architecture & Code Structure
 
@@ -162,8 +168,15 @@ Explicitly ask the user if these scripts should be run. In more cases than not, 
 
 ### Pre-Commit Checklist
 
-1. `go fmt ./...` - Format Go code
-2. `golangci-lint run --timeout 5m` - Run linter
-3. `go test -v ./...` - Run all tests
-4. `prettier '**/*.md' '**/*.yml' '**/*.json' -w` - Format markdown/JSON/YAML
-5. Verify changes work on target platforms
+The following checks run automatically via pre-commit hooks (install with `prek install`):
+
+1. `goimports` - Format imports (hook verifies no changes)
+2. `go fmt ./...` - Format Go code (hook verifies no changes)
+3. `golangci-lint run --timeout 5m` - Run linter
+4. `dprint check` - Verify markdown/YAML/JSON formatting
+5. `actionlint` - Lint GitHub Actions workflows
+
+Manual checks before submitting PRs:
+
+6. `go test -v ./...` - Run all tests (too slow for pre-commit)
+7. Verify changes work on target platforms

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,9 @@
+{
+  "lineWidth": 100,
+  "excludes": ["**/node_modules", "**/vendor", "**/*-lock.json"],
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.21.1.wasm",
+    "https://plugins.dprint.dev/markdown-0.20.0.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-0.6.0.wasm"
+  ]
+}

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,10 @@
             gocode-gomod
             godef
             golint
+            golangci-lint
+            # formatting and linting
+            dprint
+            actionlint
           ];
         };
       };


### PR DESCRIPTION
## Summary

- Add pre-commit configuration using prek (Rust-based, fast git hooks)
- Configure hooks: goimports, go fmt, golangci-lint, dprint, actionlint
- Add dprint.json for markdown/YAML/JSON formatting
- Update flake.nix with required dev tools

This prevents import drift after the recent standardization in #764 (cc9a852).

## Test plan

- [ ] Run `prek install` to install hooks
- [ ] Run `prek run --all-files` within `nix develop` shell to verify all hooks pass
- [ ] Verify `nix build` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)