### PR TITLE
tests: replace assert with require for fail-fast behavior

### DIFF
--- a/utils/testutils/test_directory_utils.go
+++ b/utils/testutils/test_directory_utils.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/crytic/medusa/utils"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // CopyToTestDirectory copies files or directories from the provided filePath (relative to ./tests/contracts/) to an
@@ -14,13 +14,13 @@ import (
 func CopyToTestDirectory(t *testing.T, filePath string) string {
 	// Construct our file path relative to our working directory
 	cwd, err := os.Getwd()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	sourcePath := filepath.Join(cwd, filePath)
 
 	// Verify the file path exists
 	sourcePathInfo, err := os.Stat(sourcePath)
-	assert.False(t, os.IsNotExist(err))
-	assert.NotNil(t, sourcePathInfo)
+	require.False(t, os.IsNotExist(err))
+	require.NotNil(t, sourcePathInfo)
 
 	// Obtain an isolated test directory path.
 	targetDirectory := filepath.Join(t.TempDir(), "medusaTest")
@@ -31,11 +31,11 @@ func CopyToTestDirectory(t *testing.T, filePath string) string {
 	} else {
 		err = utils.CopyFile(sourcePath, targetPath)
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get a normalized absolute path
 	targetPath, err = filepath.Abs(targetPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return targetPath
 }
 
@@ -45,12 +45,12 @@ func CopyToTestDirectory(t *testing.T, filePath string) string {
 func ExecuteInDirectory(t *testing.T, testPath string, method func()) {
 	// Backup our old working directory
 	cwd, err := os.Getwd()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check if the test path refers to a file or directory, as we'll want to change our working directory to a
 	// directory path.
 	testPathInfo, err := os.Stat(testPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Ensure we obtained a directory from our path
 	testDirectory := testPath
@@ -60,12 +60,12 @@ func ExecuteInDirectory(t *testing.T, testPath string, method func()) {
 
 	// Change our working directory to the test directory
 	err = os.Chdir(testDirectory)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Execute the given method
 	method()
 
 	// Restore our working directory (we must leave the test directory or else clean up will fail post testing)
 	err = os.Chdir(cwd)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- Replace `assert` with `require` from testify in `utils/testutils/test_directory_utils.go`
- Ensures tests fail fast rather than continuing after a failure
- Prevents panics when `os.Stat` fails and subsequent code attempts to dereference `nil`

Fixes #86

## Test plan

- [x] Verified project builds successfully with `go build ./...`
- [x] Verified code passes linting with `golangci-lint run --timeout 5m`
- [x] Verified code is properly formatted with `goimports` and `go fmt`

Generated with [Claude Code](https://claude.com/claude-code)