### PR TITLE
cmd: add automated versioning with git info

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,16 +4,15 @@ import (
 	"os"
 
 	"github.com/crytic/medusa/logging"
+	"github.com/crytic/medusa/version"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
 
-const version = "1.4.1"
-
 // rootCmd represents the root CLI command object which all other commands stem from.
 var rootCmd = &cobra.Command{
 	Use:     "medusa",
-	Version: version,
+	Version: version.GetInfo().Short(),
 	Short:   "A Solidity smart contract fuzzing harness",
 	Long:    "medusa is a solidity smart contract fuzzing harness",
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/crytic/medusa/version"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command that displays build information.
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version and build information",
+	Long: `Print detailed version and build information for medusa.
+
+This includes the semantic version, git commit hash, build timestamp,
+and Go version used to compile the binary.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		info := version.GetInfo()
+		fmt.Print(info.String())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,125 @@
+// Package version provides build and version information for medusa.
+// It uses Go's runtime/debug.ReadBuildInfo() to extract VCS metadata
+// embedded at build time (Go 1.18+).
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+// These variables can be set via ldflags at build time for explicit versioning.
+// If not set, they will be populated from runtime/debug.ReadBuildInfo().
+var (
+	// Version is the semantic version of the build.
+	Version = "1.4.1"
+	// GitCommit is the git commit hash.
+	GitCommit = ""
+	// GitCommitTime is the timestamp of the git commit.
+	GitCommitTime = ""
+	// GitTreeDirty indicates if the git tree was dirty at build time.
+	GitTreeDirty = ""
+)
+
+// Info contains the full version information for the build.
+type Info struct {
+	Version       string
+	GitCommit     string
+	GitCommitTime string
+	GitTreeDirty  bool
+	GoVersion     string
+}
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	// Extract VCS info from build settings
+	for _, kv := range info.Settings {
+		switch kv.Key {
+		case "vcs.revision":
+			if GitCommit == "" {
+				GitCommit = kv.Value
+			}
+		case "vcs.time":
+			if GitCommitTime == "" {
+				GitCommitTime = kv.Value
+			}
+		case "vcs.modified":
+			if GitTreeDirty == "" {
+				GitTreeDirty = kv.Value
+			}
+		}
+	}
+}
+
+// GetInfo returns the complete version information.
+func GetInfo() Info {
+	return Info{
+		Version:       Version,
+		GitCommit:     GitCommit,
+		GitCommitTime: GitCommitTime,
+		GitTreeDirty:  GitTreeDirty == "true",
+		GoVersion:     runtime.Version(),
+	}
+}
+
+// ShortCommit returns the first 7 characters of the git commit hash.
+func (i Info) ShortCommit() string {
+	if len(i.GitCommit) >= 7 {
+		return i.GitCommit[:7]
+	}
+	return i.GitCommit
+}
+
+// FormattedTime returns the commit time in a human-readable format.
+func (i Info) FormattedTime() string {
+	if i.GitCommitTime == "" {
+		return "unknown"
+	}
+	t, err := time.Parse(time.RFC3339, i.GitCommitTime)
+	if err != nil {
+		return i.GitCommitTime
+	}
+	return t.Format("2006-01-02 15:04:05 MST")
+}
+
+// String returns a formatted multi-line version string.
+func (i Info) String() string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("medusa version %s\n", i.Version))
+
+	if i.GitCommit != "" {
+		commit := i.ShortCommit()
+		if i.GitTreeDirty {
+			commit += "-dirty"
+		}
+		sb.WriteString(fmt.Sprintf("  Commit:     %s\n", commit))
+	}
+
+	if i.GitCommitTime != "" {
+		sb.WriteString(fmt.Sprintf("  Built:      %s\n", i.FormattedTime()))
+	}
+
+	sb.WriteString(fmt.Sprintf("  Go version: %s\n", i.GoVersion))
+
+	return sb.String()
+}
+
+// Short returns a single-line version string suitable for --version output.
+func (i Info) Short() string {
+	v := i.Version
+	if i.GitCommit != "" {
+		v += "+" + i.ShortCommit()
+		if i.GitTreeDirty {
+			v += "-dirty"
+		}
+	}
+	return v
+}


### PR DESCRIPTION
## Summary
- Add a `version` package that uses Go's `runtime/debug.ReadBuildInfo()` to extract VCS metadata (commit hash, timestamp, dirty flag) embedded at build time
- Create a new `medusa version` command that displays full version information including git commit, build time, and Go version
- Update the `--version` flag to show a compact format with commit hash appended

## Details

This implementation uses Go 1.18+'s built-in VCS stamping feature, which automatically embeds git metadata during `go build`. No custom build scripts or ldflags are required.

### Version command output
```
medusa version 1.4.1
  Commit:     abc1234
  Built:      2024-01-22 10:30:00 UTC
  Go version: go1.22.0
```

### --version flag output
```
medusa version 1.4.1+abc1234
```

When the tree has uncommitted changes, the commit shows as `abc1234-dirty`.

**Note:** Due to a [known Go issue with git worktrees](https://github.com/golang/go/issues/58218), VCS info may not be embedded when building from a worktree directory. The implementation gracefully handles this case by omitting the VCS fields.

## Test plan
- [x] `go build` compiles successfully
- [x] `./medusa version` displays version information
- [x] `./medusa --version` displays compact version
- [x] `golangci-lint run --timeout 5m ./cmd/... ./version/...` passes
- [x] Code formatted with `goimports` and `go fmt`

Fixes #209

Generated with [Claude Code](https://claude.com/claude-code)