### PR TITLE
ci: fix dprint plugin URL and add docs-check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,10 @@ repos:
         language: system
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: false
+
+      - id: docs-check
+        name: docs-check
+        entry: python3 scripts/check_docs.py
+        language: system
+        files: (\.go$|docs/src/.*\.md$)
+        pass_filenames: false

--- a/dprint.json
+++ b/dprint.json
@@ -4,6 +4,6 @@
   "plugins": [
     "https://plugins.dprint.dev/json-0.21.1.wasm",
     "https://plugins.dprint.dev/markdown-0.20.0.wasm",
-    "https://plugins.dprint.dev/g-plane/pretty_yaml-0.6.0.wasm"
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm"
   ]
 }


### PR DESCRIPTION
## Summary

- Fix dprint pretty_yaml plugin URL that was returning 404 errors (`pretty_yaml-0.6.0` -> `pretty_yaml-v0.6.0`)
- Add `docs-check` to pre-commit hooks so documentation sync issues are caught locally before pushing

## Problem

The dprint hook was failing with a 404 error when trying to download the pretty_yaml plugin because the URL was missing the `v` prefix in the version.

The docs-check CI was failing on PRs because new config fields weren't documented, but this wasn't being caught locally since docs-check wasn't in the pre-commit hooks.

## Changes

1. **dprint.json**: Fixed plugin URL from `pretty_yaml-0.6.0.wasm` to `pretty_yaml-v0.6.0.wasm`
2. **.pre-commit-config.yaml**: Added `docs-check` hook that runs `python3 scripts/check_docs.py` on `.go` files and `docs/src/**/*.md` files

🤖 Generated with [Claude Code](https://claude.ai/code)