### PR TITLE
Fix event parser panic from insufficient topics (#789)

### DIFF
--- a/compilation/abiutils/solidity_events.go
+++ b/compilation/abiutils/solidity_events.go
@@ -15,6 +15,11 @@ func UnpackEventAndValues(contractAbi *abi.ABI, eventLog *coreTypes.Log) (*abi.E
 		return nil, nil
 	}
 
+	// Ensure we have at least one topic (the event signature).
+	if len(eventLog.Topics) == 0 {
+		return nil, nil
+	}
+
 	// Obtain an event definition matching this event log's first topic.
 	event, err := contractAbi.EventByID(eventLog.Topics[0])
 	if err != nil {
@@ -44,6 +49,11 @@ func UnpackEventAndValues(contractAbi *abi.ABI, eventLog *coreTypes.Log) (*abi.E
 		} else {
 			unindexedInputArguments = append(unindexedInputArguments, arg)
 		}
+	}
+
+	// Verify we have enough topics for all indexed inputs (1 topic for signature + N for indexed args).
+	if len(eventLog.Topics) < len(indexedInputArguments)+1 {
+		return nil, nil
 	}
 
 	// Next, aggregate all topics into a single buffer, so we can treat it like data to unpack from.


### PR DESCRIPTION
## Summary

Fixes panic in event parsing when processing events with insufficient topics. This commonly occurs with `vm.etch` cheatcode when compiled ABI doesn't match runtime bytecode.

## Changes

Added two bounds checks to `UnpackEventAndValues` in `compilation/abiutils/solidity_events.go`:

1. **Check Topics array is non-empty** (before accessing `Topics[0]`)
2. **Verify sufficient topics exist for indexed arguments** (before accessing `Topics[i+1]`)

Both checks return `nil` on failure, maintaining consistency with existing error handling patterns in the codebase.

## Behavior

- Event unpacking failures now return gracefully without panics
- Execution traces display `<unresolved(topics=[...], data=...)>` for unresolvable events  
- No behavior changes for valid events
- Consistent error handling pattern across codebase

## Testing

- All existing tests pass (`go test -v ./...`)
- Code formatted and linted

Fixes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)