### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/chain/test_chain_test.go
+++ b/chain/test_chain_test.go
@@ -209,7 +209,6 @@ func TestChainDynamicDeployments(t *testing.T) {
 		for _, compilation := range compilations {
 			for _, source := range compilation.SourcePathToArtifact {
 				for _, contract := range source.Contracts {
-					contract := contract
 					if len(contract.Abi.Constructor.Inputs) == 0 {
 						// Listen for contract changes
 						deployedContracts := 0
@@ -332,7 +331,6 @@ func TestChainDeploymentWithArgs(t *testing.T) {
 		for _, compilation := range compilations {
 			for _, source := range compilation.SourcePathToArtifact {
 				for contractName, contract := range source.Contracts {
-					contract := contract
 
 					// Listen for contract changes
 					deployedContracts := 0
@@ -454,7 +452,6 @@ func TestChainCloning(t *testing.T) {
 		for _, compilation := range compilations {
 			for _, source := range compilation.SourcePathToArtifact {
 				for _, contract := range source.Contracts {
-					contract := contract
 					if len(contract.Abi.Constructor.Inputs) == 0 {
 						for i := 0; i < 10; i++ {
 							// Deploy the currently indexed contract next
@@ -551,7 +548,6 @@ func TestChainCallSequenceReplayMatchSimple(t *testing.T) {
 		for _, compilation := range compilations {
 			for _, source := range compilation.SourcePathToArtifact {
 				for _, contract := range source.Contracts {
-					contract := contract
 					if len(contract.Abi.Constructor.Inputs) == 0 {
 						for i := 0; i < 10; i++ {
 							// Create a message to represent our contract deployment.

--- a/fuzzing/valuegeneration/abi_values_test.go
+++ b/fuzzing/valuegeneration/abi_values_test.go
@@ -123,8 +123,6 @@ func getTestABIArguments() abi.Arguments {
 
 	// Add arguments that are arrays of each basic type
 	for _, basicArg := range basicArgs {
-		// Alias our arg so when we get a pointer to it, we don't cause a memory leak in this loop
-		basicArg := basicArg
 
 		// Define our array arguments.
 		arrayArgs := abi.Arguments{
@@ -161,7 +159,6 @@ func getTestABIArguments() abi.Arguments {
 
 		// Now for those slices/arrays, we create nested ones
 		for _, arrayArg := range arrayArgs {
-			arrayArg := arrayArg
 
 			// Add nested slice/arrays.
 			args = append(args,


### PR DESCRIPTION
## Description


The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore



**Related Issues:** <!-- Closes #XXX -->

**Type of Change:**

- [ ] Bug Fix
- [ ] New Feature
- [x] Refactoring
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Tests
- [ ] Other (please describe):

## Testing

<!-- How was this tested? What test coverage exists? -->

## Additional Context

<!-- Optional: Add any additional context, screenshots, performance impacts, breaking changes, or related information -->

## Outstanding TODOs

<!-- List any remaining work, known issues, or follow-up tasks -->
