### PR TITLE
compilation: normalize user-defined ABI types in crytic exports

### DIFF
--- a/compilation/types/compiled_contract.go
+++ b/compilation/types/compiled_contract.go
@@ -13,6 +13,8 @@ import (
 	"github.com/crytic/medusa-geth/common"
 )
 
+var abiArraySuffixExpression = regexp.MustCompile(`(\[[0-9]*\])+$`)
+
 // CompiledContract represents a single contract unit from a smart contract compilation.
 type CompiledContract struct {
 	// Abi describes a contract's application binary interface, a structure used to describe information needed
@@ -98,29 +100,115 @@ func (c *CompiledContract) IsMatch(initBytecode []byte, runtimeBytecode []byte) 
 
 // ParseABIFromInterface parses a generic object into an abi.ABI and returns it, or an error if one occurs.
 func ParseABIFromInterface(i any) (*abi.ABI, error) {
-	var (
-		result abi.ABI
-		err    error
-	)
+	abiDefinition, err := abiInterfaceToString(i)
+	if err != nil {
+		return nil, err
+	}
 
-	// If it's a string, just parse it. Otherwise, we assume it's an interface and serialize it into a string.
+	result, err := abi.JSON(strings.NewReader(abiDefinition))
+	if err == nil {
+		return &result, nil
+	}
+
+	normalizedDefinition, changed, normalizeErr := normalizeABIDefinitionTypes(abiDefinition)
+	if normalizeErr != nil || !changed {
+		return nil, err
+	}
+
+	result, err = abi.JSON(strings.NewReader(normalizedDefinition))
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func abiInterfaceToString(i any) (string, error) {
 	if s, ok := i.(string); ok {
-		result, err = abi.JSON(strings.NewReader(s))
-		if err != nil {
-			return nil, err
+		return s, nil
+	}
+
+	b, err := json.Marshal(i)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func normalizeABIDefinitionTypes(abiDefinition string) (string, bool, error) {
+	var root any
+	if err := json.Unmarshal([]byte(abiDefinition), &root); err != nil {
+		return "", false, err
+	}
+
+	changed := normalizeABITypeFieldsInValue(root)
+	if !changed {
+		return abiDefinition, false, nil
+	}
+
+	normalizedBytes, err := json.Marshal(root)
+	if err != nil {
+		return "", false, err
+	}
+
+	return string(normalizedBytes), true, nil
+}
+
+func normalizeABITypeFieldsInValue(value any) bool {
+	changed := false
+
+	switch node := value.(type) {
+	case map[string]any:
+		rawType, hasType := node["type"].(string)
+		internalType, hasInternalType := node["internalType"].(string)
+		if hasType && hasInternalType {
+			normalizedType := normalizeABITypeValue(rawType, internalType)
+			if normalizedType != rawType {
+				node["type"] = normalizedType
+				changed = true
+			}
 		}
-	} else {
-		var b []byte
-		b, err = json.Marshal(i)
-		if err != nil {
-			return nil, err
+
+		for _, nested := range node {
+			if normalizeABITypeFieldsInValue(nested) {
+				changed = true
+			}
 		}
-		result, err = abi.JSON(strings.NewReader(string(b)))
-		if err != nil {
-			return nil, err
+	case []any:
+		for _, nested := range node {
+			if normalizeABITypeFieldsInValue(nested) {
+				changed = true
+			}
 		}
 	}
-	return &result, nil
+
+	return changed
+}
+
+func normalizeABITypeValue(rawType string, internalType string) string {
+	if rawType == "" || internalType == "" {
+		return rawType
+	}
+
+	internalType = strings.TrimSpace(internalType)
+	arraySuffix := abiArraySuffixExpression.FindString(rawType)
+	if arraySuffix == "" {
+		arraySuffix = abiArraySuffixExpression.FindString(internalType)
+	}
+
+	switch {
+	case strings.HasPrefix(internalType, "contract "), strings.HasPrefix(internalType, "interface "):
+		return "address" + arraySuffix
+	case strings.HasPrefix(internalType, "enum "):
+		return "uint8" + arraySuffix
+	case strings.HasPrefix(internalType, "struct "):
+		if strings.HasPrefix(rawType, "tuple") {
+			return rawType
+		}
+		return "tuple" + arraySuffix
+	default:
+		return rawType
+	}
 }
 
 func (c *CompiledContract) DecodeLinkedInitBytecodeBytes() ([]byte, error) {

--- a/compilation/types/compiled_contract_test.go
+++ b/compilation/types/compiled_contract_test.go
@@ -1,0 +1,93 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/crytic/medusa-geth/accounts/abi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseABIFromInterface_NormalizesUserDefinedTypes(t *testing.T) {
+	rawABI := []map[string]any{
+		{
+			"type": "function",
+			"name": "computeL",
+			"inputs": []map[string]any{
+				{
+					"name":         "positions",
+					"type":         "tuple[]",
+					"internalType": "struct NftRef[]",
+					"components": []map[string]any{
+						{
+							"name":         "kind",
+							"type":         "NftKind",
+							"internalType": "enum NftKind",
+						},
+						{
+							"name":         "tokenId",
+							"type":         "uint248",
+							"internalType": "uint248",
+						},
+					},
+				},
+				{
+					"name":         "positionManager",
+					"type":         "IPositionManager",
+					"internalType": "contract IPositionManager",
+				},
+				{
+					"name":         "loManager",
+					"type":         "ILimitOrderManager",
+					"internalType": "interface ILimitOrderManager",
+				},
+				{
+					"name":         "keepers",
+					"type":         "IKeeper[]",
+					"internalType": "contract IKeeper[]",
+				},
+			},
+			"outputs": []map[string]any{
+				{
+					"name":         "",
+					"type":         "uint256",
+					"internalType": "uint256",
+				},
+			},
+			"stateMutability": "view",
+		},
+	}
+
+	encodedABI, err := json.Marshal(rawABI)
+	require.NoError(t, err)
+
+	_, err = abi.JSON(strings.NewReader(string(encodedABI)))
+	require.Error(t, err, "control check: raw ABI should fail with user-defined type aliases")
+
+	parsedABI, err := ParseABIFromInterface(string(encodedABI))
+	require.NoError(t, err)
+
+	method, ok := parsedABI.Methods["computeL"]
+	require.True(t, ok)
+	require.Len(t, method.Inputs, 4)
+
+	positions := method.Inputs[0]
+	require.Equal(t, abi.SliceTy, positions.Type.T)
+	require.NotNil(t, positions.Type.Elem)
+	require.Equal(t, abi.TupleTy, positions.Type.Elem.T)
+	require.Len(t, positions.Type.Elem.TupleElems, 2)
+
+	kindField := positions.Type.Elem.TupleElems[0]
+	assert.Equal(t, abi.UintTy, kindField.T)
+	assert.Equal(t, 8, kindField.Size)
+
+	assert.Equal(t, abi.AddressTy, method.Inputs[1].Type.T)
+	assert.Equal(t, abi.AddressTy, method.Inputs[2].Type.T)
+
+	keepers := method.Inputs[3]
+	require.Equal(t, abi.SliceTy, keepers.Type.T)
+	require.NotNil(t, keepers.Type.Elem)
+	assert.Equal(t, abi.AddressTy, keepers.Type.Elem.T)
+}


### PR DESCRIPTION
## Summary
- Fix ABI parsing failures from crytic-compile exports where ABI entries use user-defined names in `type` (for example enum/contract/interface aliases) instead of canonical ABI types.
- Add a fallback in `ParseABIFromInterface` to normalize ABI `type` fields using `internalType` (`enum -> uint8`, `contract/interface -> address`, `struct -> tuple`) while preserving array suffixes, then retry parsing.
- Add a regression test that reproduces the alias-based parse failure and validates successful parsing after normalization for nested tuple and array cases.

## Why
Running `medusa fuzz` against a harness can fail before the fuzzing starts with `unable to parse ABI for contract 'CollateralFloorMath'`. The exported ABI contained alias-like `type` values (e.g. `NftKind`, `IPositionManager`) that the ABI parser rejects. This change makes Medusa resilient to that export shape without changing behavior for already-canonical ABIs.

## Test plan
- [x] `go test -v ./compilation/types -run TestParseABIFromInterface_NormalizesUserDefinedTypes`
- [x] `go fmt ./...`
- [x] `python3 scripts/check_docs.py`
- [x] `golangci-lint run --timeout 5m0s`
- [x] `actionlint`