### PR TITLE
Start with 2^128 instead of 2^256 eth

### DIFF
--- a/fuzzing/fuzzer.go
+++ b/fuzzing/fuzzer.go
@@ -553,8 +553,9 @@ func (f *Fuzzer) createTestChain() (*chain.TestChain, error) {
 	// NOTE: Sharing GenesisAlloc between chains will result in some accounts not being funded for some reason.
 	genesisAlloc := make(types.GenesisAlloc)
 
-	// Fund all of our sender addresses in the genesis block with 2^256-1 ETH equivalent
-	initBalance := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1))
+	// Fund all of our sender addresses in the genesis block with 2^128-1 ETH equivalent.
+	// This should both prevent us from running out of gas and prevent us from overflowing above 2^256 eth.
+	initBalance := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil), big.NewInt(1))
 	for _, sender := range f.senders {
 		genesisAlloc[sender] = types.Account{
 			Balance: new(big.Int).Set(initBalance),


### PR DESCRIPTION
Very simple code change. Start sender addresses with 2^128 eth instead of 2^256. This should prevent overflow over 2^256 while still preventing out-of-gas. Fixes the following test case which previously caused medusa to error:

```solidity
contract SimpleBalanceDrain {
    function deposit() public payable {}

    function withdraw() public {
        uint256 amount = address(this).balance;
        payable(msg.sender).call{value: amount}("");
    }
}
```

Previously we got the following error:
```
error Encountered an error in the main fuzzing loop
‣ test chain state write error when adding tx to pending block: insufficient funds for gas * price + value: address 0x0000000000000000000000000000000000010000 have 4026804785036390882 want 18446744073709551615
```

This is because we overflowed a uint256 when adding onto 2^256-1