### PR TITLE
deps: bump medusa-geth to fix vm.etch bytecode aliasing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
           pname = "medusa";
           version = "1.5.1";
           src = ./.;
-          vendorHash = "sha256-r4p49cnObkugiEvGZx6bgXhjMbS5tMdfJsAJ7KzWW10=";
+          vendorHash = "sha256-519gQaZH1btzLTf+vQGr4rGHzJHmjd0w9S2Uk6NuI0Y=";
           nativeBuildInputs = [
             crytic.packages.${system}.crytic-compile
             crytic.packages.${system}.slither

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/bmatcuk/doublestar/v4 v4.9.2
-	github.com/crytic/medusa-geth v0.0.0-20250423141023-d818338d6925
+	github.com/crytic/medusa-geth v0.0.0-20260420202548-b162a9edb4bb
 	github.com/fxamacker/cbor v1.5.1
 	github.com/google/uuid v1.6.0
 	github.com/holiman/uint256 v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a h1:W8mUrRp6NOV
 github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a/go.mod h1:sTwzHBvIzm2RfVCGNEBZgRyjwK40bVoun3ZnGOCafNM=
 github.com/crate-crypto/go-kzg-4844 v1.1.0 h1:EN/u9k2TF6OWSHrCCDBBU6GLNMq88OspHHlMnHfoyU4=
 github.com/crate-crypto/go-kzg-4844 v1.1.0/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
-github.com/crytic/medusa-geth v0.0.0-20250423141023-d818338d6925 h1:CeTtLPdvD7uMvaa4VBXNLVCmePvv75yEQb8gR0q+Rsc=
-github.com/crytic/medusa-geth v0.0.0-20250423141023-d818338d6925/go.mod h1:Of9UoKsMjqZO047+RArQyB0t9/+YeJAHiKHM5vGPUU8=
+github.com/crytic/medusa-geth v0.0.0-20260420202548-b162a9edb4bb h1:U9VeknMXu3P4BqxaB6FgPsvUONxPDg7RuuIhGck4vI8=
+github.com/crytic/medusa-geth v0.0.0-20260420202548-b162a9edb4bb/go.mod h1:Of9UoKsMjqZO047+RArQyB0t9/+YeJAHiKHM5vGPUU8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

- Bumps `medusa-geth` to include [crytic/medusa-geth#4](https://github.com/crytic/medusa-geth/pull/4), which fixes a byte-slice aliasing bug in `stateObject.SetCode`
- Bytecode installed via `vm.etch` was stored by reference instead of being cloned, so if the underlying buffer was reused the stored code could become corrupted, causing `invalid jump destination` and other erratic failures

Fixes #827

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify with the reporter's repro contract that etched and normally-deployed contracts now behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)