### PR TITLE
Skip invalid Slither constants during value seeding

### DIFF
--- a/fuzzing/valuegeneration/value_set_from_slither.go
+++ b/fuzzing/valuegeneration/value_set_from_slither.go
@@ -14,7 +14,10 @@ func (vs *ValueSet) SeedFromSlither(slither *compilationTypes.SlitherResults) {
 	for _, constant := range slither.Constants {
 		// Capture uint/int types
 		if strings.HasPrefix(constant.Type, "uint") || strings.HasPrefix(constant.Type, "int") {
-			var b, _ = new(big.Int).SetString(constant.Value, 10)
+			b, ok := new(big.Int).SetString(constant.Value, 10)
+			if !ok {
+				continue
+			}
 			vs.AddInteger(b)
 			vs.AddInteger(new(big.Int).Neg(b))
 			vs.AddBytes(b.Bytes())
@@ -31,7 +34,10 @@ func (vs *ValueSet) SeedFromSlither(slither *compilationTypes.SlitherResults) {
 			vs.AddBytes([]byte(constant.Value))
 		} else if constant.Type == "address" {
 			// Capture addresses
-			var addressBigInt, _ = new(big.Int).SetString(constant.Value, 10)
+			addressBigInt, ok := new(big.Int).SetString(constant.Value, 10)
+			if !ok {
+				continue
+			}
 			vs.AddAddress(common.BigToAddress(addressBigInt))
 			vs.AddBytes([]byte(constant.Value))
 		}


### PR DESCRIPTION
## Description

Fixes a startup panic in Slither-backed value seeding.

`SeedFromSlither` ignored the `ok` result from `big.Int.SetString` in both the integer and address branches. If Slither emits a numeric- or address-typed constant whose value is not a valid base-10 string, Medusa passed a nil `*big.Int` into downstream value-seeding code and panicked: `(*big.Int).Neg(nil)` for the integer branch and `common.BigToAddress(nil) -> b.Bytes()` for the address branch.

This change keeps the existing decimal-only parsing behavior and skips constants that cannot be parsed.

**Related Issues:** Closes #830

**Type of Change:**

- [x] Bug Fix
- [x] Tests

## Testing

Run inside a fresh clone on `dev/slither-seed-parse-failure`:

```bash
go fmt ./...
go vet ./fuzzing/valuegeneration/
go test ./fuzzing/valuegeneration/
go test ./...
golangci-lint run --timeout 5m0s
```

The new test `TestSeedFromSlitherInvalidUintDoesNotPanic` panics on stock `master` at `value_set_from_slither.go:19` and `TestSeedFromSlitherInvalidAddressDoesNotPanic` panics at line 35; both pass after the patch.

## Additional Context

`0x` parsing is intentionally not added in this PR to keep the bug fix separable from a behavior expansion. The existing AST-based seed path in `value_set_from_ast.go` already handles `0x`-prefixed numeric values; whether the Slither-based path should match it is a separate discussion.

## Outstanding TODOs

None.
