### PR TITLE
docs: add agent-focused OpenWiki documentation and fix stale AGENTS.md claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,27 +23,27 @@ Medusa is a cross-platform smart contract fuzzer written in Go, built on go-ethe
 
 ### Lint & Format
 
-- `goimports -w .` - Format imports and code (groups stdlib, external, local)
+- `goimports -w .` - Format imports and code (groups stdlib vs. external; no `-local` grouping is configured)
 - `go fmt ./...` - Format Go code (required before commits)
 - `golangci-lint run --timeout 5m` - Run comprehensive lint checks (mirrors CI)
-- `dprint fmt` - Format markdown, YAML, and JSON files
+- `dprint fmt` - Format markdown, YAML, and JSON files (note: CI enforces `prettier --check` on `**.json`/`**/*.md`/`**/*.yml`, which can disagree with dprint — run prettier before pushing)
 - `actionlint` - Lint GitHub Actions workflow files
 
 ### Run
 
-- `go run . --config path/to/config.yaml` - Compile and run the fuzzer
+- `go run . fuzz --config path/to/medusa.json` - Compile and run the fuzzer (`--config` is a flag of the `fuzz` subcommand; configs are JSON)
 - `nix develop` - Enter the pinned Nix development shell with all dependencies
 
 ### Git Hooks
 
 - `prek install` - Install pre-commit hooks (run once after cloning)
-- `prek run` - Manually run all pre-commit checks (use within `nix develop` shell)
+- `prek run` - Manually run all pre-commit checks (the hook tools are provided by the `nix develop` shell; `prek` itself is installed separately)
 
 ## Architecture & Code Structure
 
 ### Module Responsibilities
 
-- **`cmd/`** - CLI entry point using Cobra framework. Defines `fuzz`, `init`, and `completion` commands.
+- **`cmd/`** - CLI entry point using Cobra framework. Defines `fuzz`, `init`, `corpus` (with a `corpus clean` subcommand), and `completion` commands.
 - **`fuzzing/`** - Core fuzzing orchestration including workers, corpus management, coverage tracking, value generation, and test case providers.
 - **`chain/`** - EVM test harness (TestChain) built on medusa-geth with state management and cheat code support (vm.\* functions).
 - **`compilation/`** - Smart contract compilation abstraction with platform adapters for solc and crytic-compile.
@@ -60,20 +60,20 @@ cmd/fuzz.go (Cobra Command)
   ↓
 fuzzing.NewFuzzer(ProjectConfig)
   ├─→ Compilation (compile contracts via crytic-compile/solc)
-  ├─→ FuzzerWorker pool (N parallel workers)
-  ├─→ TestChain per worker (isolated EVM instance)
   ├─→ Corpus (loads/saves coverage-increasing call sequences)
-  ├─→ Test Case Providers (Assertion, Property, Optimization)
-  └─→ Coverage Tracer (if enabled)
+  └─→ Test Case Providers (Assertion, Property, Optimization)
+
+Fuzzer.Start()
+  ├─→ Deploys target contracts once on a base TestChain (ChainSetupFunc hook)
+  └─→ FuzzerWorker pool (N parallel workers; each clones the base chain into
+      its own isolated TestChain, with a per-worker coverage tracer if enabled)
 
 Worker Loop (per worker, in parallel):
-  1. Deploy contracts via ChainSetupFunc hook
-  2. Generate CallSequence (mutations from corpus)
-  3. Execute sequence on TestChain
-  4. Run CallSequenceTestFuncs (test case providers)
-  5. If test fails → shrink sequence → save to corpus
-  6. Update coverage maps
-  7. Reset chain state to base block → repeat
+  1. Generate CallSequence (mutations from corpus)
+  2. Execute the sequence on TestChain — per call: update coverage maps /
+     corpus, then run CallSequenceTestFuncs (test case providers)
+  3. If test fails → shrink sequence → save to corpus
+  4. Reset chain state to base block (testingBaseBlockIndex) → repeat
 ```
 
 ### Key Architectural Patterns
@@ -85,9 +85,9 @@ Worker Loop (per worker, in parallel):
 - `NewCallSequenceGeneratorConfigFunc` - Customize sequence generation strategy
 - `NewShrinkingValueMutatorFunc` - Customize shrinking heuristics
 - `ChainSetupFunc` - Customize deployment and initialization logic
-- `CallSequenceTestFuncs[]` - Register test functions to run after each sequence
+- `CallSequenceTestFuncs[]` - Register test functions to run after each call in a sequence
 
-**Coverage-Guided Fuzzing**: The corpus stores only call sequences that increase coverage. Sequences are mutated using weighted strategies (corpus head/tail, splice, interleave, new). A corpus pruner periodically removes redundant sequences to keep the corpus lean.
+**Coverage-Guided Fuzzing**: The corpus stores only call sequences that increase coverage. Sequences are mutated using weighted strategies (corpus head, corpus tail, splice, interleave — each in unmodified and mutated variants); entirely new sequences are generated with a separate `NewSequenceProbability`. A corpus pruner periodically removes redundant sequences to keep the corpus lean.
 
 **Worker-Based Parallelization**: Each `FuzzerWorker` has its own isolated `TestChain` instance with no shared state. Workers are periodically destroyed and recreated (`WorkerResetLimit`) to prevent memory bloat from geth's state accumulation.
 
@@ -101,11 +101,11 @@ Worker Loop (per worker, in parallel):
 
 - **`CallSequence`** - Array of `CallSequenceElement` representing a transaction sequence to execute on the test chain.
 - **`CallSequenceElement`** - Single call with target address, method, arguments, block delay, and gas limit.
-- **`TestCase` interface** - Represents a test with Status (NOT_STARTED, RUNNING, PASSED, FAILED), Name, CallSequence, and result Message.
-- **`Corpus`** - Persistent storage of coverage-increasing call sequences with pruning. Stored on disk in `corpus/` directory.
+- **`TestCase` interface** - Represents a test with Status (`NOT STARTED`, `RUNNING`, `PASSED`, `FAILED`), Name, CallSequence, and result Message.
+- **`Corpus`** - Storage of coverage-increasing call sequences with pruning. Persisted to disk only when `corpusDirectory` is set (default is empty → in-memory only, not flushed).
 - **`CoverageMaps`** - Tracks branch coverage per contract (including jumps, returns, reverts, and contract entrance), used to identify coverage-increasing sequences.
 - **`FuzzerWorker`** - Single execution thread with its own TestChain, deployed contracts, and sequence generator.
-- **`ProjectConfig`** - Top-level configuration containing FuzzingConfig, CompilationConfig, LoggingConfig.
+- **`ProjectConfig`** - Top-level configuration containing FuzzingConfig, CompilationConfig, SlitherConfig, LoggingConfig.
 - **`FuzzingConfig`** - Workers count, timeout, test limit, corpus directory, coverage settings, test case configurations.
 
 ### Test Case Providers
@@ -113,8 +113,8 @@ Worker Loop (per worker, in parallel):
 Three built-in test case providers run concurrently:
 
 1. **AssertionTestCaseProvider**: Monitors EVM-level panic conditions for each contract method (e.g., `assert()`, arithmetic underflow/overflow, divide by zero, array access violations). Which panic codes trigger test failures is configured via `PanicCodeConfig` in `FuzzingConfig.Testing.AssertionTesting`.
-2. **PropertyTestCaseProvider**: Calls property test functions (prefix-based naming, must be view functions returning bool). If a property returns false, the test fails.
-3. **OptimizationTestCaseProvider**: Tracks optimization targets (e.g., maximize gas usage) and shrinks sequences to find minimal paths to targets.
+2. **PropertyTestCaseProvider**: Calls property test functions (prefix-based naming, no arguments, returning bool; `view`/`pure` by convention — state mutability is not enforced, calls are made read-only). If a property returns false (or reverts), the test fails.
+3. **OptimizationTestCaseProvider**: Calls prefix-named no-argument functions returning `int256` and searches for call sequences that maximize the returned value, shrinking to find minimal paths to the best value.
 
 ## Testing Guidelines
 
@@ -175,8 +175,21 @@ The following checks run automatically via pre-commit hooks (install with `prek 
 3. `golangci-lint run --timeout 5m` - Run linter
 4. `dprint check` - Verify markdown/YAML/JSON formatting
 5. `actionlint` - Lint GitHub Actions workflows
+6. `docs-check` - Run `python3 scripts/check_docs.py` to verify docs are in sync
 
 Manual checks before submitting PRs:
 
-6. `go test -v ./...` - Run all tests (too slow for pre-commit)
-7. Verify changes work on target platforms
+7. `go test -v ./...` - Run all tests (too slow for pre-commit)
+8. Verify changes work on target platforms
+
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,13 @@
 @AGENTS.md
+
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,0 +1,6 @@
+{
+  "updatedAt": "2026-07-06T07:55:22.403Z",
+  "command": "init",
+  "gitHead": "66bb59d05502a2a6362507df0bad6b5d0b3a6185",
+  "model": "claude-opus-4-8"
+}

--- a/openwiki/architecture/chain-and-state.md
+++ b/openwiki/architecture/chain-and-state.md
@@ -1,0 +1,81 @@
+# Chain & State (`/chain`)
+
+The [`/chain`](../../chain) package is medusa's in-process EVM harness. Each `FuzzerWorker` owns one `TestChain`
+instance, giving every worker an isolated blockchain to deploy contracts and execute call sequences against. It is
+built on **medusa-geth** (crytic's fork of go-ethereum).
+
+## TestChain (`test_chain.go`)
+
+`TestChain` is the isolated EVM node abstraction. Key responsibilities:
+
+- Maintain a chain of blocks and account state; produce blocks for each call in a sequence.
+- Support **snapshots / reverts** so the worker can rebase to `testingBaseBlockIndex` after each sequence (cheap
+  state reset instead of re-deploying).
+- Install tracers: the deployments tracer (`test_chain_deployments_tracer.go`) detects dynamically deployed
+  contracts, and the coverage tracer records coverage.
+- Emit chain events (`test_chain_events.go`) consumed by the fuzzer.
+
+Reference: [`chain/test_chain.go`](../../chain/test_chain.go),
+[`chain/test_chain_tracer.go`](../../chain/test_chain_tracer.go).
+
+## State backends (`/chain/state`)
+
+State is abstracted behind two interfaces so the engine is agnostic to where account state comes from:
+
+- **`MedusaStateDB`** (in [`/chain/types`](../../chain/types)) — the EVM state database interface.
+- **`MedusaStateFactory`** (`state/factories.go`) — thread-safe factory for creating state DBs, allowing globally
+  shared data (like RPC caches) across all `TestChain` instances.
+
+Three factory implementations exist ([`chain/state/factories.go`](../../chain/state/factories.go)):
+
+| Factory                 | Backend                             | Used for                                                |
+| ----------------------- | ----------------------------------- | ------------------------------------------------------- |
+| `VanillaStateDbFactory` | Native geth `state.New`             | Normal in-memory fuzzing.                               |
+| `ForkedStateFactory`    | Remote RPC via `stateBackend`       | **Fork mode** — lazily fetch state from a live network. |
+| `UnbackedStateFactory`  | `EmptyBackend` with forked-DB logic | Forked-DB semantics without a real remote source.       |
+
+### Fork mode (`/chain/state/rpc`, `/chain/state/cache`)
+
+When `chainConfig.forkConfig.forkModeEnabled` is set, medusa backs EVM state with a remote RPC:
+
+- `remote_state_provider.go` lazily fetches accounts/storage/code from the RPC as the EVM touches them.
+- `rpc/client_pool.go` manages a pool of RPC clients (`forkConfig.poolSize`); recent history includes memory-leak
+  fixes in the fork-mode RPC pool.
+- `cache/persistent_cache.go` caches remote state on disk so repeated runs avoid redundant RPC calls.
+
+Fork settings: `forkConfig.rpcUrl`, `forkConfig.rpcBlock`, `forkConfig.poolSize`. Defined in
+[`chain/config/config.go`](../../chain/config/config.go); consumed by
+[`chain/state/rpc_backend.go`](../../chain/state/rpc_backend.go).
+
+### Genesis / pre-deployed state (`genesis_loader.go`)
+
+`chainConfig.genesisStateFile` loads a genesis allocation so you can fuzz contracts deployed **outside** medusa
+(e.g. via a Foundry/Anvil deployment). Formats auto-detected: native `anvil_dumpState`, decompressed anvil wrapper
+JSON, and plain accounts JSON. `chainConfig.genesisContractMappings` maps genesis addresses to compiled contract
+names so the fuzzer knows which ABIs/functions to call. Fuzzer-generated accounts take precedence over loaded state.
+Reference: [`chain/state/genesis_loader.go`](../../chain/state/genesis_loader.go) and the user doc
+[`docs/src/testing/genesis_state.md`](../../docs/src/testing/genesis_state.md).
+
+## Cheat codes (`cheat_code_*`, `standard_cheat_code_contract.go`)
+
+Cheat codes are Foundry-style `vm.*` functions implemented as **pre-compiled contracts**:
+
+- `CheatCodeContract` (`cheat_code_contract.go`) registers a table of function selectors → handlers.
+- `standard_cheat_code_contract.go` implements the standard `vm.*` cheat codes (`warp`, `roll`, `prank`, `deal`,
+  `etch`, `store`/`load`, `sign`, parsing helpers, `ffi`, `assert*`, snapshots, etc.).
+- `console_log_cheat_code_contract.go` implements `console.log` support.
+- `cheat_code_tracer.go` provides the EVM execution hooks cheat codes rely on (e.g. prank scoping).
+
+Cheat codes are gated by `chainConfig.cheatCodes` (`cheatCodesEnabled`, and `enableFFI` for the dangerous `ffi`
+code). The authoritative per-cheatcode reference is the mdBook:
+[`docs/src/cheatcodes/cheatcodes_overview.md`](../../docs/src/cheatcodes/cheatcodes_overview.md).
+
+## Change-oriented notes
+
+- Adding a cheat code: implement a handler in `standard_cheat_code_contract.go` (or a new contract), register the
+  selector, and document it under `docs/src/cheatcodes/`. Tests live in
+  [`chain/test_chain_test.go`](../../chain/test_chain_test.go) and `fuzzing/testdata/contracts/cheat_codes/`.
+- Fork-mode changes: watch for memory leaks and cache correctness; tests under `chain/state/` cover providers,
+  factories, and the genesis loader.
+- EVM behavior toggles live in [`chain/config/config.go`](../../chain/config/config.go)
+  (`codeSizeCheckDisabled`, `skipAccountChecks`, `contractAddressOverrides`).

--- a/openwiki/architecture/fuzzing-engine.md
+++ b/openwiki/architecture/fuzzing-engine.md
@@ -1,0 +1,126 @@
+# Fuzzing Engine (`/fuzzing`)
+
+The [`/fuzzing`](../../fuzzing) package is the heart of medusa. This page explains its subsystems and how they
+interact during a campaign. For the step-by-step campaign flow, see
+[../workflows/fuzzing-lifecycle.md](../workflows/fuzzing-lifecycle.md).
+
+## Fuzzer (`fuzzer.go`)
+
+`Fuzzer` is the top-level orchestrator. It:
+
+- Holds the `ProjectConfig`, the list of compilations, and the derived `contractDefinitions`.
+- Owns the shared `baseValueSet` (seed values for fuzzing), the `corpus`, `metrics`, and optional
+  `revertReporter` and `corpusPruner`.
+- Manages the worker pool and two contexts: a normal `ctx` (best-effort cancellation) and an `emergencyCtx`
+  (guaranteed termination on SIGINT/errors).
+- Registers the built-in test case providers on construction.
+
+Entry points: `NewFuzzer(config)` and `Fuzzer.Start()`. See [`fuzzing/fuzzer.go`](../../fuzzing/fuzzer.go).
+
+## Worker (`fuzzer_worker.go`)
+
+`FuzzerWorker` is a single fuzzing thread. Each worker owns:
+
+- Its own `chain.TestChain` (isolated EVM) and a `coverageTracer`.
+- `testingBaseBlockIndex` — the block after all target contracts are deployed; the worker **reverts to this block
+  after every sequence** to reset state cheaply.
+- Classified method lists: `stateChangingMethods`, `pureMethods` (view/pure), and `fallbackMethods`.
+- A `sequenceGenerator`, a `shrinkingValueMutator`, and a worker-local `valueSet` derived from the fuzzer's base set
+  plus runtime values.
+
+The worker runs the inner fuzzing loop and processes any pending `shrinkCallSequenceRequests` before generating the
+next sequence. See [`fuzzing/fuzzer_worker.go`](../../fuzzing/fuzzer_worker.go).
+
+## Call sequences (`/fuzzing/calls`)
+
+- **`CallSequence`** — an ordered array of `CallSequenceElement`s executed against the test chain while maintaining
+  state (until the sequence ends and state is reset).
+- **`CallSequenceElement` / `CallMessage`** — a single call: target address, method, ABI-encoded arguments, block
+  number/timestamp delay, gas limit, and sender.
+
+Execution helpers live in [`fuzzing/calls/call_sequence_execution.go`](../../fuzzing/calls/call_sequence_execution.go).
+The maximum sequence length is `fuzzing.callSequenceLength` (default 100).
+
+## Sequence generation (`fuzzer_worker_sequence_generator.go`)
+
+`CallSequenceGenerator` builds each new sequence either from scratch or by mutating corpus entries, chosen by a
+**weighted random selector**. Configurable strategies (see `CallSequenceGeneratorConfig`) include:
+
+- New entirely-random sequence (`NewSequenceProbability`).
+- Take corpus **head** and append new calls; take corpus **tail** and prepend new calls.
+- **Splice** two corpus sequences; **interleave** calls from two corpus sequences.
+- Mutated variants of the above (with value mutations applied to arguments).
+
+This is the mechanism that turns coverage feedback into deeper exploration. Reference:
+[`fuzzing/fuzzer_worker_sequence_generator.go`](../../fuzzing/fuzzer_worker_sequence_generator.go).
+
+## Value generation (`/fuzzing/valuegeneration`)
+
+Generates and mutates ABI argument values.
+
+- `generator_random.go` — random value generation for each ABI type.
+- `generator_mutational.go` — mutates existing values (bit flips, boundary values, value-set values such as
+  AST/Slither constants and runtime return values).
+- `mutator_shrinking.go` — value mutations used during shrinking (see below).
+- `value_set.go` / `value_set_from_ast.go` / `value_set_from_slither.go` — the seed **value set**, populated from
+  compilation AST constants and Slither-extracted constants (recent history: commit _"skip invalid Slither
+  constants during seeding"_ touched `value_set_from_slither.go`).
+- `abi_values.go` — encoding/decoding and value helpers for ABI types.
+
+## Corpus (`/fuzzing/corpus`)
+
+The corpus persists **coverage-increasing** call sequences so they can be replayed and mutated in future runs.
+
+- Stored on disk under the configured `corpus/` directory (in-memory only if `corpusDirectory` is empty).
+- A background **pruner** (`corpus_pruner`, controlled by `fuzzing.pruneFrequency`, default 5 minutes) removes
+  redundant sequences to bound size and memory. Pruning only runs when coverage is enabled.
+- `corpus_cleaner.go` supports the `medusa corpus clean` CLI command, which removes invalid/unreplayable sequences.
+
+Reference: [`fuzzing/corpus/corpus.go`](../../fuzzing/corpus/corpus.go).
+
+## Coverage (`/fuzzing/coverage`)
+
+- `coverage_tracer.go` — an EVM tracer that records executed code locations (jumps, returns, reverts, contract
+  entrance) per contract.
+- `coverage_maps.go` — the coverage data structures used to decide whether a sequence increased coverage.
+- `source_analysis.go` + `report_generation.go` + `report_template.gohtml` — map bytecode coverage back to source
+  and render HTML/LCOV reports. Report formats are set via `fuzzing.coverageFormats` (default `html`, `lcov`);
+  `fuzzing.coverageExclusions` supports glob patterns.
+
+## Test case providers (`test_case_*`)
+
+Three providers run concurrently and register `CallSequenceTestFunc` hooks:
+
+1. **Assertion** (`test_case_assertion_provider.go`) — detects EVM panic conditions per method (e.g. `assert()`,
+   overflow/underflow, divide-by-zero, out-of-bounds). Which panic codes fail is set via
+   `PanicCodeConfig` under `testing.assertionTesting`.
+2. **Property** (`test_case_property_provider.go`) — calls no-argument `bool`-returning functions matching
+   configured prefixes (default `property_`), invoked read-only; a `false` return (or revert) fails the test.
+   (`view`/`pure` is convention — state mutability is not enforced.)
+3. **Optimization** (`test_case_optimization_provider.go`) — tracks a maximization target and shrinks sequences to
+   find minimal paths that maximize it (default prefix `optimize_`).
+
+Each `TestCase` (`test_case.go`) tracks Status (`NOT STARTED`, `RUNNING`, `PASSED`, `FAILED`), name, failing call
+sequence, and a result message. See [../testing.md](../testing.md) for how to write these tests.
+
+## Shrinking (`fuzzer_worker_shrinking.go`)
+
+When a test fails, a `ShrinkCallSequenceRequest` is queued. The worker iteratively removes/mutates calls and values
+while a `VerifierFunction` confirms the test still fails, producing a **minimal reproduction**. The number of
+shrinking iterations is bounded by `fuzzing.shrinkLimit` (default 5000). Value mutations used here come from
+`valuegeneration/mutator_shrinking.go`.
+
+## Execution tracing & reverts
+
+- [`/fuzzing/executiontracer`](../../fuzzing/executiontracer) — produces human-readable execution traces for failing
+  sequences (used in reporting).
+- [`/fuzzing/reverts`](../../fuzzing/reverts) — the `RevertReporter` collects per-function revert metrics when
+  `fuzzing.revertReporterEnabled` is set.
+
+## Change-oriented notes
+
+- Most engine changes have tests in [`fuzzing/fuzzer_test.go`](../../fuzzing/fuzzer_test.go) and fixtures under
+  [`fuzzing/testdata`](../../fuzzing/testdata). Run `go test -v ./fuzzing/...`.
+- Be careful with worker isolation: shared mutable state across workers breaks determinism and parallelism.
+- Changes to coverage semantics affect corpus retention and pruning — validate with the corpus scripts in
+  [`/scripts`](../../scripts) (see [../operations.md](../operations.md)).

--- a/openwiki/architecture/overview.md
+++ b/openwiki/architecture/overview.md
@@ -1,0 +1,81 @@
+# Architecture Overview
+
+medusa is a Go program with a Cobra CLI front-end and a fuzzing engine core. This page describes the major
+components, how they fit together, and where each lives. For the detailed engine internals see
+[fuzzing-engine.md](fuzzing-engine.md); for EVM/state details see [chain-and-state.md](chain-and-state.md).
+
+The canonical prose version of this architecture lives in [`/AGENTS.md`](../../AGENTS.md) ("Architecture & Code
+Structure"). This page grounds and links that content to source.
+
+## Components
+
+| Component                | Package                                                                         | Role                                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| CLI                      | [`/cmd`](../../cmd)                                                             | Parses flags/config, loads `ProjectConfig`, constructs and starts the `Fuzzer`.                   |
+| Fuzzer                   | [`/fuzzing`](../../fuzzing) (`fuzzer.go`)                                       | Top-level orchestrator: compilation, worker pool, corpus, coverage, metrics, test case providers. |
+| Worker                   | [`/fuzzing`](../../fuzzing) (`fuzzer_worker.go`)                                | One fuzzing thread with an isolated `TestChain`; runs the inner fuzzing loop.                     |
+| Sequence generator       | `fuzzing/fuzzer_worker_sequence_generator.go`                                   | Produces new/mutated call sequences using weighted strategies.                                    |
+| Corpus                   | [`/fuzzing/corpus`](../../fuzzing/corpus)                                       | Persists coverage-increasing call sequences; prunes redundant entries.                            |
+| Coverage                 | [`/fuzzing/coverage`](../../fuzzing/coverage)                                   | EVM tracer + coverage maps + HTML/LCOV report generation.                                         |
+| Value generation         | [`/fuzzing/valuegeneration`](../../fuzzing/valuegeneration)                     | Generates/mutates ABI values; maintains the value set.                                            |
+| Calls                    | [`/fuzzing/calls`](../../fuzzing/calls)                                         | `CallSequence` / `CallMessage` data structures and execution helpers.                             |
+| Test case providers      | `fuzzing/test_case_*`                                                           | Assertion, property, and optimization test detection.                                             |
+| Chain                    | [`/chain`](../../chain)                                                         | `TestChain` EVM harness, state factories, cheat codes, tracers.                                   |
+| Compilation              | [`/compilation`](../../compilation)                                             | `solc` / `crytic-compile` adapters, ABI utils, artifact hashing.                                  |
+| Logging / Events / Utils | [`/logging`](../../logging), [`/events`](../../events), [`/utils`](../../utils) | Cross-cutting infrastructure.                                                                     |
+
+## System flow
+
+```
+main.go
+  └─ cmd.Execute() → cmd/fuzz.go (cmdRunFuzz)
+       └─ load ProjectConfig (medusa.json or defaults)
+       ├─ fuzzing.NewFuzzer(config)
+       │    ├─ compile targets (crytic-compile / solc)
+       │    ├─ derive contract definitions + base value set
+       │    └─ register test case providers (assertion/property/optimization)
+       └─ Fuzzer.Start()
+            └─ spawn N FuzzerWorkers (config.fuzzing.workers)
+
+Per worker (parallel loop):
+  1. Create isolated TestChain
+  2. Deploy target contracts → record testingBaseBlockIndex
+  3. Generate a CallSequence (new or corpus-mutated)
+  4. Execute the sequence on the TestChain
+  5. Run CallSequenceTestFuncs (test case providers) after each call
+  6. On new coverage → add sequence to corpus
+  7. On test failure → shrink sequence → report + save
+  8. Revert chain to testingBaseBlockIndex → repeat
+  9. After WorkerResetLimit sequences → destroy + recreate worker (free memory)
+```
+
+Reference: [`fuzzing/fuzzer.go`](../../fuzzing/fuzzer.go), [`fuzzing/fuzzer_worker.go`](../../fuzzing/fuzzer_worker.go),
+[`cmd/fuzz.go`](../../cmd/fuzz.go).
+
+## Key architectural patterns
+
+- **Worker-based parallelization.** Each `FuzzerWorker` owns its own `TestChain` with no shared mutable state.
+  Workers are periodically destroyed and recreated (`fuzzing.workerResetLimit`, default 50) to bound memory from
+  geth's state accumulation. See `FuzzerWorker` in `fuzzing/fuzzer_worker.go`.
+- **Event-driven extensibility.** `FuzzerEvents` and `FuzzerWorkerEvents` emit lifecycle events
+  (starting/stopping, worker created/destroyed). Test case providers subscribe and register test hooks without
+  touching core logic. See [`fuzzing/fuzzer_events.go`](../../fuzzing/fuzzer_events.go),
+  [`fuzzing/fuzzer_worker_events.go`](../../fuzzing/fuzzer_worker_events.go), and the generic emitter in
+  [`/events`](../../events).
+- **Hook-based customization.** `FuzzerHooks` ([`fuzzing/fuzzer_hooks.go`](../../fuzzing/fuzzer_hooks.go)) exposes
+  override points: `NewCallSequenceGeneratorConfigFunc`, `NewShrinkingValueMutatorFunc`, `ChainSetupFunc`, and the
+  `CallSequenceTestFuncs` list. This is how the Go API extends behavior.
+- **Coverage-guided feedback loop.** Only coverage-increasing sequences are retained in the corpus; a background
+  pruner keeps it lean. See [fuzzing-engine.md](fuzzing-engine.md).
+- **State abstraction.** `MedusaStateDB` / `MedusaStateFactory` abstract the EVM state backend so the same engine
+  supports vanilla in-memory state and fork mode. See [chain-and-state.md](chain-and-state.md).
+
+## Where to start when changing things
+
+- Changing **campaign orchestration / lifecycle**: `fuzzing/fuzzer.go`, `fuzzing/fuzzer_worker.go`.
+- Changing **how inputs are generated/mutated**: `fuzzing/valuegeneration/`, `fuzzing/fuzzer_worker_sequence_generator.go`.
+- Adding a **new kind of test**: add a `test_case_*_provider.go` and register it (see `fuzzing/fuzzer.go`).
+- Changing **EVM behavior / cheat codes**: `chain/`.
+- Changing **CLI or config**: `cmd/`, `fuzzing/config/`, `chain/config/`.
+
+See [reference/source-map.md](../reference/source-map.md) for a fuller index.

--- a/openwiki/operations.md
+++ b/openwiki/operations.md
@@ -1,0 +1,90 @@
+# Operations: Build, CLI, Configuration & Tooling
+
+This page is the practical reference for building medusa, running it, configuring it, and using its developer
+tooling. It complements [`/AGENTS.md`](../AGENTS.md) and [`/DEV.md`](../DEV.md).
+
+## Build
+
+```bash
+go build                 # compile the medusa CLI binary
+./medusa --help          # verify the built binary
+nix build                # build with Nix (update flake.nix vendorHash after go.mod changes)
+nix develop              # enter the pinned Nix dev shell with all deps
+```
+
+The version string lives in [`cmd/root.go`](../cmd/root.go) (and is bumped in `flake.nix` on release). Entrypoint:
+[`main.go`](../main.go) → `cmd.Execute()`.
+
+## Lint & format (run before committing)
+
+```bash
+goimports -w .                       # order imports (stdlib, then external; no -local grouping configured)
+go fmt ./...                         # format Go
+golangci-lint run --timeout 5m       # comprehensive lint (mirrors CI)
+dprint fmt                           # format markdown/YAML/JSON (config: dprint.json)
+actionlint                           # lint GitHub Actions workflows
+```
+
+Pre-commit hooks automate these (`prek install` once, then `prek run`). Config:
+[`.pre-commit-config.yaml`](../.pre-commit-config.yaml). Docs consistency is enforced in CI by
+[`scripts/check_docs.py`](../scripts/check_docs.py).
+
+## CLI commands (`/cmd`)
+
+Built with Cobra. Root command in [`cmd/root.go`](../cmd/root.go).
+
+| Command                  | File                                        | Purpose                                                              |
+| ------------------------ | ------------------------------------------- | -------------------------------------------------------------------- |
+| `medusa init [platform]` | [`cmd/init.go`](../cmd/init.go)             | Scaffold a `medusa.json` project config (optionally for a platform). |
+| `medusa fuzz`            | [`cmd/fuzz.go`](../cmd/fuzz.go)             | Run a fuzzing campaign (uses `medusa.json` or `--config`).           |
+| `medusa corpus clean`    | [`cmd/corpus.go`](../cmd/corpus.go)         | Remove invalid/unreplayable sequences from a corpus.                 |
+| `medusa completion`      | [`cmd/completion.go`](../cmd/completion.go) | Generate shell completion scripts.                                   |
+
+Common examples:
+
+```bash
+medusa init                      # create default medusa.json
+medusa fuzz                      # run using medusa.json in cwd
+medusa fuzz --config custom.json # run with an explicit config
+go run . --config medusa.json    # compile + run from source
+```
+
+Many `fuzz` flags override config fields (see [`cmd/fuzz_flags.go`](../cmd/fuzz_flags.go)). Exit codes are defined in
+[`/cmd/exitcodes`](../cmd/exitcodes). Full CLI docs: [`docs/src/cli/overview.md`](../docs/src/cli/overview.md).
+
+## Configuration
+
+The top-level config is `ProjectConfig` ([`fuzzing/config/config.go`](../fuzzing/config/config.go)), serialized as
+`medusa.json` with four top-level sections (`fuzzing`, `compilation`, `slither`, `logging`); `testing` and
+`chainConfig` are sub-objects nested **inside** `fuzzing`:
+
+| Section               | Struct                          | Highlights (with defaults from `config_defaults.go`)                                                                                                                                                                                                                                                  |
+| --------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fuzzing`             | `FuzzingConfig`                 | `workers` (10), `workerResetLimit` (50), `callSequenceLength` (100), `shrinkLimit` (5000), `timeout` (0=∞), `testLimit` (0=∞), `pruneFrequency` (5 min), `coverageEnabled` (true), `coverageFormats` (`html`,`lcov`), `targetContracts`, `deployerAddress`, `senderAddresses`, `transactionGasLimit`. |
+| `fuzzing.testing`     | `TestingConfig`                 | `stopOnFailedTest`, `testViewMethods`, `verbosity`, `assertionTesting`, `propertyTesting` (prefix `property_`), `optimizationTesting` (prefix `optimize_`), target/exclude function signatures.                                                                                                       |
+| `fuzzing.chainConfig` | `chain/config.TestChainConfig`  | `cheatCodes`, `forkConfig` (fork mode), `genesisStateFile`/`genesisContractMappings`, `contractAddressOverrides`, `codeSizeCheckDisabled`, `skipAccountChecks`.                                                                                                                                       |
+| `compilation`         | `compilation.CompilationConfig` | Platform (`crytic-compile`/`solc`) and platform-specific args.                                                                                                                                                                                                                                        |
+| `slither`             | `types.SlitherConfig`           | Slither integration used to seed constants into the value set.                                                                                                                                                                                                                                        |
+| `logging`             | `LoggingConfig`                 | Single `level` for console/file output, `logDirectory` (non-empty enables file logging), `noColor`.                                                                                                                                                                                                   |
+
+Per-field reference (user docs): [`docs/src/project_configuration/overview.md`](../docs/src/project_configuration/overview.md)
+and its sub-pages. See [architecture/chain-and-state.md](architecture/chain-and-state.md) for fork/genesis details.
+
+## Corpus tooling (`/scripts`)
+
+> Per [`/AGENTS.md`](../AGENTS.md): only run these when explicitly needed; most changes don't touch them.
+
+```bash
+python3 scripts/corpus_diff.py corpus1 corpus2   # methods present in one corpus but not the other
+python3 scripts/corpus_stats.py corpus           # sequence count, avg length, method frequency
+```
+
+See [`/DEV.md`](../DEV.md) for example output.
+
+## Deployment / distribution
+
+- Install: `go install github.com/crytic/medusa@latest`.
+- Container: [`Dockerfile`](../Dockerfile).
+- Nix flake: [`flake.nix`](../flake.nix) / [`flake.lock`](../flake.lock). Update `vendorHash` after `go.mod`
+  changes (`nix build` reports the correct hash).
+- CI workflows live under [`.github/workflows`](../.github/workflows).

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,0 +1,84 @@
+# medusa — OpenWiki Quickstart
+
+`medusa` is a cross-platform, [go-ethereum](https://github.com/ethereum/go-ethereum/)-based
+**smart contract fuzzer** written in Go, developed by [crytic](https://github.com/crytic) and inspired by
+[Echidna](https://github.com/crytic/echidna). It performs **parallelized, coverage-guided fuzz testing** of
+Solidity smart contracts, driven either from the CLI or from a Go API for user-extended testing.
+
+Source of truth for this overview: [`/README.md`](../README.md), [`/AGENTS.md`](../AGENTS.md), and
+[`/main.go`](../main.go).
+
+> This OpenWiki is an opinionated **map and synthesis layer** over the repository. The project already ships
+> extensive user-facing documentation as an mdBook under [`/docs/src`](../docs/src/SUMMARY.md), and a detailed
+> agent guide in [`/AGENTS.md`](../AGENTS.md). This wiki tells you _how the codebase is organized and where to
+> change things_; the mdBook tells end users _how to use medusa_. Prefer linking to those docs over duplicating them.
+
+## What medusa does
+
+Given one or more Solidity contracts, medusa:
+
+1. Compiles the target project (via `crytic-compile` or `solc`).
+2. Spins up a pool of parallel workers, each with an isolated in-process EVM (`TestChain`, built on medusa-geth).
+3. Deploys the target contracts and repeatedly generates + executes random/mutated **call sequences**.
+4. Runs **test case providers** (assertion, property, optimization) after each call in a sequence to detect invariant violations.
+5. Uses **coverage feedback** to keep interesting call sequences in a **corpus** and mutate them to explore deeper.
+6. When a test fails, **shrinks** the failing sequence to a minimal reproduction and reports it.
+
+## Key features
+
+- Parallel fuzzing across multiple workers (see `fuzzing.workers`).
+- Assertion, property, and optimization testing (built-in test case providers).
+- Coverage-guided fuzzing with an on-disk corpus and periodic pruning.
+- Mutational value generation seeded from compilation artifacts and runtime values.
+- Foundry-style **cheat codes** (`vm.*`) and `console.log` support.
+- **Fork mode**: back the EVM state with a remote RPC; separately, a genesis state file can preload Anvil
+  `anvil_dumpState` output.
+- HTML + LCOV coverage reports and per-function revert reporting.
+
+## Repository layout
+
+| Path                              | Responsibility                                                                                  |
+| --------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [`/main.go`](../main.go)          | Process entrypoint; delegates to `cmd.Execute()`.                                               |
+| [`/cmd`](../cmd)                  | Cobra CLI: `fuzz`, `init`, `corpus clean`, `completion`. Flag parsing and exit codes.           |
+| [`/fuzzing`](../fuzzing)          | Core engine: `Fuzzer`, workers, corpus, coverage, value generation, calls, test case providers. |
+| [`/chain`](../chain)              | `TestChain` EVM harness, state management/factories, cheat codes, tracers.                      |
+| [`/compilation`](../compilation)  | Compilation abstraction with `solc` and `crytic-compile` platform adapters + ABI utils.         |
+| [`/logging`](../logging)          | Structured logging (zerolog) with console + file writers.                                       |
+| [`/events`](../events)            | Generic event-emitter system used for lifecycle hooks.                                          |
+| [`/utils`](../utils)              | Shared helpers (random values, reflection, file ops).                                           |
+| [`/docs`](../docs/src/SUMMARY.md) | mdBook user documentation.                                                                      |
+| [`/scripts`](../scripts)          | Python helpers for corpus analysis and docs checks.                                             |
+
+## Run it quickly
+
+```bash
+go build                       # build the medusa binary
+./medusa init                  # scaffold a medusa.json config in the current project
+./medusa fuzz                  # run a fuzzing campaign using medusa.json
+go run . fuzz --config medusa.json  # compile + run in one step
+```
+
+See [operations.md](operations.md) for the full build/test/lint and CLI reference.
+
+## Where to go next
+
+- **[architecture/overview.md](architecture/overview.md)** — components, package map, and system flow.
+- **[architecture/fuzzing-engine.md](architecture/fuzzing-engine.md)** — the `fuzzing/` package: fuzzer, workers,
+  sequence generation, corpus, coverage, value generation, shrinking, and test case providers.
+- **[architecture/chain-and-state.md](architecture/chain-and-state.md)** — the `TestChain`, state factories,
+  fork mode, and cheat codes.
+- **[workflows/fuzzing-lifecycle.md](workflows/fuzzing-lifecycle.md)** — end-to-end lifecycle of a campaign.
+- **[testing.md](testing.md)** — invariant types, writing tests, and running the Go test suite.
+- **[operations.md](operations.md)** — building, CLI usage, configuration, and corpus tooling.
+- **[reference/source-map.md](reference/source-map.md)** — "I want to change X, where do I look?" index.
+
+## Ground rules for editing this codebase (for agents)
+
+- Follow the conventions in [`/AGENTS.md`](../AGENTS.md): `area: intent` commit format, doc comments on all exported
+  symbols, `filepath` (not `path`) for cross-platform correctness, camelCase JSON keys, ≤32-char file names
+  (a stated convention — note several existing files exceed it).
+- Run `go fmt ./...`, `goimports -w .`, and `golangci-lint run --timeout 5m` before committing.
+- Run `go test -v ./...` for verification; target packages with `go test -v ./fuzzing/...`.
+- User-facing behavior changes usually require updating [`/docs/src`](../docs/src/SUMMARY.md) — CI runs a docs check
+  (`/scripts/check_docs.py`).

--- a/openwiki/reference/source-map.md
+++ b/openwiki/reference/source-map.md
@@ -1,0 +1,82 @@
+# Source Map & Change Guide
+
+A navigation index for the medusa codebase, plus "where do I change X" pointers. For narrative explanations, follow
+the links into the architecture pages.
+
+## Top-level layout
+
+| Path                                                                                                    | What it is                                                                                                   |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [`/main.go`](../../main.go)                                                                             | Process entrypoint → `cmd.Execute()`.                                                                        |
+| [`/cmd`](../../cmd)                                                                                     | Cobra CLI: `init`, `fuzz`, `corpus clean`, `completion`; flags; exit codes.                                  |
+| [`/fuzzing`](../../fuzzing)                                                                             | Core fuzzing engine (see [engine page](../architecture/fuzzing-engine.md)).                                  |
+| [`/chain`](../../chain)                                                                                 | EVM harness `TestChain`, state backends, cheat codes (see [chain page](../architecture/chain-and-state.md)). |
+| [`/compilation`](../../compilation)                                                                     | solc / crytic-compile adapters, ABI utils, artifact hashing.                                                 |
+| [`/logging`](../../logging)                                                                             | Zerolog-based structured logging.                                                                            |
+| [`/events`](../../events)                                                                               | Generic event emitter used for lifecycle hooks.                                                              |
+| [`/utils`](../../utils)                                                                                 | Shared helpers (random, reflection, files).                                                                  |
+| [`/docs`](../../docs)                                                                                   | mdBook user documentation (`docs/src`).                                                                      |
+| [`/scripts`](../../scripts)                                                                             | Corpus diff/stats + docs check (Python).                                                                     |
+| [`/AGENTS.md`](../../AGENTS.md), [`/DEV.md`](../../DEV.md), [`/CONTRIBUTING.md`](../../CONTRIBUTING.md) | Contributor guidance.                                                                                        |
+| [`/Dockerfile`](../../Dockerfile), [`/flake.nix`](../../flake.nix), [`/.github`](../../.github)         | Build/CI/distribution.                                                                                       |
+
+## `/fuzzing` breakdown
+
+| Path                                                               | Role                                                                    |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `fuzzer.go`                                                        | Orchestrator (`Fuzzer`, `NewFuzzer`, `Start`).                          |
+| `fuzzer_worker.go`                                                 | Worker + inner fuzzing loop.                                            |
+| `fuzzer_worker_sequence_generator.go`                              | Call sequence generation strategies.                                    |
+| `fuzzer_worker_shrinking.go`                                       | Failing-sequence shrinking.                                             |
+| `fuzzer_hooks.go` / `fuzzer_events.go` / `fuzzer_worker_events.go` | Extensibility hooks & lifecycle events.                                 |
+| `fuzzer_metrics.go`                                                | Campaign metrics.                                                       |
+| `test_case*.go`, `test_case_*_provider.go`                         | Assertion / property / optimization test types.                         |
+| `calls/`                                                           | `CallSequence`, `CallMessage`, execution.                               |
+| `corpus/`                                                          | Corpus storage, pruning (`corpus_pruner`), cleaning (`corpus_cleaner`). |
+| `coverage/`                                                        | Coverage tracer, maps, source analysis, HTML/LCOV reports.              |
+| `valuegeneration/`                                                 | Random/mutational value generators, value set, shrinking mutator.       |
+| `contracts/`                                                       | Contract & method definitions derived from compilation.                 |
+| `executiontracer/`                                                 | Human-readable execution traces for failures.                           |
+| `reverts/`                                                         | Per-function revert metrics reporter.                                   |
+| `config/`                                                          | `ProjectConfig`, `FuzzingConfig`, defaults.                             |
+| `testdata/`                                                        | Solidity fixtures for end-to-end tests.                                 |
+
+## `/chain` breakdown
+
+| Path                                                                                                                      | Role                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `test_chain.go`                                                                                                           | Isolated EVM node with snapshots/reverts.                                                                            |
+| `test_chain_tracer.go`, `test_chain_deployments_tracer.go`                                                                | `TestChainTracer` interface + deployment/self-destruct detection (the coverage tracer lives in `fuzzing/coverage/`). |
+| `test_chain_events.go`                                                                                                    | Chain lifecycle events.                                                                                              |
+| `cheat_code_contract.go`, `standard_cheat_code_contract.go`, `console_log_cheat_code_contract.go`, `cheat_code_tracer.go` | Cheat codes (`vm.*`, `console.log`).                                                                                 |
+| `config/`                                                                                                                 | `TestChainConfig` (cheat codes, fork, genesis, EVM toggles).                                                         |
+| `state/`                                                                                                                  | `MedusaStateFactory` implementations, fork RPC (`state/rpc`), cache (`state/cache`), genesis loader.                 |
+| `types/`                                                                                                                  | `MedusaStateDB` interface and chain types.                                                                           |
+
+## `/compilation` breakdown
+
+| Path                                                                         | Role                                                       |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `supported_platforms.go`, `compilation_config.go`                            | Platform selection & config.                               |
+| `platforms/solc.go`, `platforms/crytic_compile.go`, `platforms/interface.go` | Compilation adapters.                                      |
+| `abiutils/`                                                                  | Solidity error/panic decoding and event unpacking helpers. |
+| `artifact_hash.go`                                                           | Detects unchanged artifacts to skip recompilation.         |
+| `types/`                                                                     | Compilation/artifact/Slither result types.                 |
+
+## "Where do I change X?"
+
+| Goal                                    | Start here                                                                | Tests / checks                                                                                                  |
+| --------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Change campaign orchestration/lifecycle | `fuzzing/fuzzer.go`, `fuzzing/fuzzer_worker.go`                           | `fuzzing/fuzzer_test.go`                                                                                        |
+| Change input generation/mutation        | `fuzzing/valuegeneration/`, `fuzzing/fuzzer_worker_sequence_generator.go` | `fuzzing/valuegeneration/*_test.go`, `fuzzing/fuzzer_test.go`                                                   |
+| Add a new test case type                | new `fuzzing/test_case_*_provider.go` + register in `fuzzing/fuzzer.go`   | fixtures in `fuzzing/testdata/`, `fuzzing/fuzzer_test.go`                                                       |
+| Change coverage / reports               | `fuzzing/coverage/`                                                       | `go test ./fuzzing/...` (no unit tests in `coverage/` itself — exercised via `fuzzer_test.go`), corpus scripts  |
+| Add / change a cheat code               | `chain/standard_cheat_code_contract.go`                                   | `TestCheatCodes` in `fuzzing/fuzzer_test.go`, `fuzzing/testdata/contracts/cheat_codes/`, `docs/src/cheatcodes/` |
+| Change EVM/state/fork behavior          | `chain/state/`, `chain/config/config.go`                                  | `chain/state/*_test.go`                                                                                         |
+| Change CLI or flags                     | `cmd/*.go`                                                                | manual `./medusa --help`, `docs/src/cli/`                                                                       |
+| Change config schema/defaults           | `fuzzing/config/config*.go`, `chain/config/`                              | `fuzzing/config/config_test.go`, `docs/src/project_configuration/`, `scripts/check_docs.py`                     |
+| Change compilation                      | `compilation/platforms/`                                                  | `compilation/platforms/*_test.go`                                                                               |
+
+Always run `go fmt ./...`, `goimports -w .`, and `golangci-lint run` before committing (see
+[../operations.md](../operations.md)). File names should stay ≤ 32 chars per the stated convention (Windows path
+limits) — though several existing files exceed it; JSON keys use camelCase.

--- a/openwiki/testing.md
+++ b/openwiki/testing.md
@@ -1,0 +1,70 @@
+# Testing: Writing Invariants & Running the Suite
+
+This page covers two things: how medusa **tests smart contracts** (the product), and how to **test medusa itself**
+(the codebase).
+
+## Part 1 — How medusa tests contracts
+
+medusa detects violations of **invariants** (a.k.a. properties): unchanging truths about a system. It breaks them
+into two categories (see [`docs/src/testing/invariants.md`](../docs/src/testing/invariants.md)):
+
+- **Function-level invariants** — properties that must hold from executing a single function.
+- **System-level invariants** — properties that must hold across the whole system after arbitrary interactions.
+
+### Test case types
+
+Three built-in test case providers evaluate these invariants (implementation:
+[architecture/fuzzing-engine.md](architecture/fuzzing-engine.md)):
+
+| Type             | How you write it                                                                                                            | How it fails                              | Config                                                           |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------- |
+| **Assertion**    | Use `assert(...)` / cheat-code assertions inside functions                                                                  | An EVM panic with a configured panic code | `testing.assertionTesting.panicCodeConfig`                       |
+| **Property**     | No-argument function returning `bool`, named with a prefix (`view`/`pure` by convention — state mutability is not enforced) | Returns `false` (or the call reverts)     | `testing.propertyTesting.testPrefixes` (default `property_`)     |
+| **Optimization** | No-argument function returning `int256`, named with a prefix; medusa maximizes the returned value                           | N/A (reports best value + minimal path)   | `testing.optimizationTesting.testPrefixes` (default `optimize_`) |
+
+Authoritative how-to guides (user docs):
+
+- [Writing function-level invariants](../docs/src/testing/writing-function-level-invariants.md)
+- [Writing system-level invariants](../docs/src/testing/writing-system-level-invariants.md)
+- [Reporting / interpreting results](../docs/src/testing/reporting.md)
+
+### Interpreting results
+
+When a test fails, medusa prints the **shrunk (minimal) call sequence** plus an execution trace (from
+[`/fuzzing/executiontracer`](../fuzzing/executiontracer)). Coverage reports (HTML/LCOV) and optional revert reports
+are written at the end of the campaign. `testing.verbosity` controls output detail.
+
+## Part 2 — Testing medusa (the Go codebase)
+
+Tests are co-located with implementations as `*_test.go` (see [`/AGENTS.md`](../AGENTS.md) "Testing Guidelines").
+
+```bash
+go test -v ./...                       # run all unit + integration tests
+go test -v ./fuzzing/...               # run a specific package
+go test -v -run TestName ./package/... # run one test
+go test -cover ./...                   # with coverage metrics
+```
+
+Notable test areas:
+
+- [`fuzzing/fuzzer_test.go`](../fuzzing/fuzzer_test.go) — large end-to-end fuzzer tests using Solidity fixtures in
+  [`fuzzing/testdata/contracts`](../fuzzing/testdata/contracts) (assertion tests, property tests, cheat codes, etc.).
+- [`chain/test_chain_test.go`](../chain/test_chain_test.go) — TestChain harness (reverting, block jumping, dynamic
+  deployments, cloning, call-sequence replay); cheat-code behavior is tested by `TestCheatCodes` in
+  [`fuzzing/fuzzer_test.go`](../fuzzing/fuzzer_test.go).
+- [`chain/state/*_test.go`](../chain/state) — state factories, remote/fork providers, genesis loading.
+- [`compilation/platforms/*_test.go`](../compilation/platforms) — solc/crytic-compile adapters.
+- [`fuzzing/config/config_test.go`](../fuzzing/config/config_test.go) — config parsing/defaults.
+
+Conventions: table-driven tests for deterministic logic; add `t.Parallel()` where safe; end-to-end fuzzer tests can
+be slow (they compile Solidity and run real campaigns), which is why the full suite is a manual pre-PR check rather
+than a pre-commit hook.
+
+### Change-oriented guidance
+
+- Adding a new test case type: add a `test_case_*_provider.go`, register it in `fuzzing/fuzzer.go`, add fixtures
+  under `fuzzing/testdata/contracts/`, and add a `TestName` in `fuzzing/fuzzer_test.go`.
+- Adding a cheat code: extend `chain/standard_cheat_code_contract.go`, add a fixture under
+  `fuzzing/testdata/contracts/cheat_codes/`, and update `docs/src/cheatcodes/`.
+- User-facing behavior/config changes: update [`/docs/src`](../docs/src/SUMMARY.md); CI runs
+  [`/scripts/check_docs.py`](../scripts/check_docs.py) to verify docs stay in sync.

--- a/openwiki/workflows/fuzzing-lifecycle.md
+++ b/openwiki/workflows/fuzzing-lifecycle.md
@@ -1,0 +1,85 @@
+# Workflow: The Fuzzing Lifecycle
+
+This page describes what happens end-to-end during a `medusa fuzz` campaign, tying together the CLI, engine, and
+chain. It is a condensed, code-anchored version of the user-facing lifecycle doc
+[`docs/src/testing/fuzzing_lifecycle.md`](../../docs/src/testing/fuzzing_lifecycle.md); read that for diagrams and
+worked examples, and see [../architecture/fuzzing-engine.md](../architecture/fuzzing-engine.md) for component detail.
+
+## 1. Startup & configuration
+
+`main.go` → `cmd.Execute()` → `cmd/fuzz.go` (`cmdRunFuzz`) resolves the `ProjectConfig`:
+
+1. If `--config` is given, load that file (error if unreadable/missing).
+2. Else load `medusa.json` from the working directory.
+3. Else fall back to the default project config (`fuzzing/config/config_defaults.go`).
+4. Finally, explicitly-set CLI flags (`--workers`, `--timeout`, `--deployer`, …) override the loaded config
+   (`updateProjectConfigWithFuzzFlags` in [`cmd/fuzz_flags.go`](../../cmd/fuzz_flags.go)).
+
+The config is then handed to `fuzzing.NewFuzzer(config)`. Reference: [`cmd/fuzz.go`](../../cmd/fuzz.go),
+[`fuzzing/config/config.go`](../../fuzzing/config/config.go).
+
+## 2. Compilation & target discovery
+
+The fuzzer compiles the target project through the configured platform (`crytic-compile` or `solc`, see
+[`/compilation`](../../compilation)), derives `contractDefinitions`, and builds the `baseValueSet` from AST/Slither
+constants. Target contracts to fuzz come from `fuzzing.targetContracts` (or all contracts if
+`testing.testAllContracts` is true).
+
+## 3. Worker pool
+
+`Fuzzer.Start()` spawns `fuzzing.workers` (default 10) `FuzzerWorker` goroutines, each with an isolated
+`chain.TestChain`. See [../architecture/chain-and-state.md](../architecture/chain-and-state.md).
+
+## 4. Deployment (once, on a shared base chain)
+
+Before workers spawn, `Fuzzer.Start()` deploys the target contracts **once** on a base `TestChain` via
+`ChainSetupFunc` (using `fuzzing.deployerAddress`), including any contracts dynamically deployed during
+construction. Each worker then **clones** that base chain, replaying its deployment blocks, and records the
+post-deployment block as `testingBaseBlockIndex` — the **initial deployment state** the worker reverts to between
+sequences. Optional pre-deployed / genesis state can be loaded first (see chain docs). Reference: `ChainSetupFunc`
+in [`fuzzing/fuzzer_hooks.go`](../../fuzzing/fuzzer_hooks.go).
+
+## 5. The inner fuzzing loop (per worker, repeated)
+
+```
+loop until timeout / testLimit / failure (if stopOnFailedTest):
+  1. Generate a CallSequence
+       - with NewSequenceProbability: a fully random sequence
+       - otherwise: mutate corpus entries (head/tail/splice/interleave, with value mutations)
+  2. For each element in the sequence:
+       a. Execute the call as a transaction (blocks follow each call's fuzzed block/timestamp
+          delays — zero-delay calls may share a block)
+       b. If coverage increased → add the executed prefix to the corpus
+       c. Run test-case hooks (assertion/property/optimization) and update metrics
+  3. If a test failed → queue a ShrinkCallSequenceRequest
+  4. Revert TestChain to testingBaseBlockIndex (reset state)
+```
+
+- A **random transaction** is a call to a random method of a target contract with fuzzed arguments.
+- **Coverage** is measured by the coverage tracer; only coverage-increasing sequences are retained.
+- Reference: [`fuzzing/fuzzer_worker.go`](../../fuzzing/fuzzer_worker.go),
+  [`fuzzing/fuzzer_worker_sequence_generator.go`](../../fuzzing/fuzzer_worker_sequence_generator.go).
+
+## 6. Shrinking a failure
+
+Before generating the next sequence, the worker processes queued shrink requests: it iteratively removes calls and
+mutates values while a verifier confirms the test still fails, yielding a **minimal reproduction** (bounded by
+`fuzzing.shrinkLimit`). Reference: [`fuzzing/fuzzer_worker_shrinking.go`](../../fuzzing/fuzzer_worker_shrinking.go).
+
+## 7. Worker recycling
+
+After roughly `fuzzing.workerResetLimit` sequences (default 50), a worker is destroyed and recreated to free memory
+accumulated in geth's state. Its corpus contributions persist in the shared corpus.
+
+## 8. Corpus pruning (background)
+
+If coverage is enabled and `fuzzing.pruneFrequency` > 0 (default 5 min), a background pruner periodically removes
+redundant corpus sequences. Reference: [`fuzzing/corpus/corpus_pruner.go`](../../fuzzing/corpus/corpus_pruner.go)
+(the pruner loop; the underlying `PruneSequences` lives in [`corpus.go`](../../fuzzing/corpus/corpus.go)).
+
+## 9. Shutdown & reporting
+
+The campaign ends on timeout, `testLimit`, a failing test (if `testing.stopOnFailedTest`), or an OS interrupt. On
+shutdown medusa writes coverage reports (`fuzzing.coverageFormats`), optional revert reports
+(`fuzzing.revertReporterEnabled`), and — when coverage is enabled — flushes the corpus to disk. Exit codes are defined in
+[`/cmd/exitcodes`](../../cmd/exitcodes). See [../testing.md](../testing.md) for interpreting results.


### PR DESCRIPTION
## Summary

I used [OpenWiki](https://www.langchain.com/blog/introducing-openwiki-an-open-source-agent-for-repo-documentation) with Anthropic's Claude models (Fable 5 / Opus 4.8) to create thorough, agent-focused documentation for medusa and to audit our existing agent docs against the source code.

References #793.

Two commits:

1. **`openwiki/` — a source-grounded documentation layer for LLM agents** (plus a pointer section in `CLAUDE.md`). It's deliberately a *map/synthesis* layer: it explains how the codebase is organized and where to change things, linking to the mdBook for end-user how-tos instead of duplicating them. Pages:
   - `quickstart.md` — what medusa is, repo layout, quick-run commands
   - `architecture/overview.md`, `architecture/fuzzing-engine.md`, `architecture/chain-and-state.md`
   - `workflows/fuzzing-lifecycle.md` — end-to-end campaign flow
   - `testing.md`, `operations.md` (CLI + `ProjectConfig` schema with defaults)
   - `reference/source-map.md` — "I want to change X, where do I look?" index
2. **`AGENTS.md` accuracy fixes.** Every factual claim in the generated wiki *and* in the existing `AGENTS.md` was verified claim-by-claim against the code (~450 claims, with file:line evidence). The wiki fixes are already folded into the first commit; this commit fixes the stale/incorrect items found in `AGENTS.md`, including:
   - `cmd/` command list was missing `corpus clean`
   - `go run . --config path/to/config.yaml` → `go run . fuzz --config path/to/medusa.json` (`--config` is a `fuzz` flag; configs are JSON)
   - `OptimizationTestCaseProvider` maximizes an `int256` test-function return value, not "gas usage"
   - corpus is persisted only when `corpusDirectory` is set (default is in-memory)
   - deployment happens once on a base chain that workers clone (not per worker); test hooks run per call, not per sequence
   - property tests: `view`/`pure` is convention, not enforced by the classifier
   - added the missing `docs-check` pre-commit hook and `slither` config section; noted that CI enforces `prettier` while the local hook uses `dprint`

The same audit also covered `README.md` (clean) and the mdBook under `docs/src` — I'll submit the mdBook fixes (45 findings, e.g. non-existent `--assertion-mode`/`--optimization-mode` flags and a `coverageReports` → `coverageFormats` key error) as a separate PR to keep this one reviewable.

## Test plan

- `python3 scripts/check_docs.py` passes
- `prettier --check` / `dprint check` unaffected (new files are markdown-only additions)
- All wiki links resolve to existing files; all cited symbols/defaults verified against source at `66bb59d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)