### PR TITLE
refactor: use typed event reflection and zero-size sets

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -10,7 +10,7 @@ type EventHandler[T any] func(T) error
 
 // EventType returns the event type given an EventHandler object
 func (e *EventHandler[T]) EventType() reflect.Type {
-	return reflect.TypeOf((*T)(nil)).Elem()
+	return reflect.TypeFor[T]()
 }
 
 // globalEventHandlers describes a mapping of event types to EventHandler objects. These callbacks are called
@@ -57,7 +57,7 @@ type EventEmitter[T any] struct {
 
 // EventType returns the event type given an EventEmitter object
 func (e *EventEmitter[T]) EventType() reflect.Type {
-	return reflect.TypeOf((*T)(nil)).Elem()
+	return reflect.TypeFor[T]()
 }
 
 // Publish emits the provided event by calling every EventHandler subscribed.

--- a/fuzzing/valuegeneration/value_set.go
+++ b/fuzzing/valuegeneration/value_set.go
@@ -16,11 +16,11 @@ import (
 // ValueSet represents potential values of significance within the source code to be used in fuzz tests.
 type ValueSet struct {
 	// addresses represents a set of common.Address to use in fuzz tests. A mapping is used to avoid duplicates.
-	addresses map[common.Address]any
+	addresses map[common.Address]struct{}
 	// integers represents a set of integers to use in fuzz tests. A mapping is used to avoid duplicates.
 	integers map[string]*big.Int
 	// strings represents a set of strings to use in fuzz tests. A mapping is used to avoid duplicates.
-	strings map[string]any
+	strings map[string]struct{}
 	// bytes represents a set of bytes to use in fuzz tests. A mapping is used to avoid duplicates.
 	bytes map[string][]byte
 	// hashProvider represents a hash provider used to create keys for some data.
@@ -30,9 +30,9 @@ type ValueSet struct {
 // NewValueSet initializes a new ValueSet object for use with a Fuzzer.
 func NewValueSet() *ValueSet {
 	baseValueSet := &ValueSet{
-		addresses:    make(map[common.Address]any, 0),
+		addresses:    make(map[common.Address]struct{}, 0),
 		integers:     make(map[string]*big.Int, 0),
-		strings:      make(map[string]any, 0),
+		strings:      make(map[string]struct{}, 0),
 		bytes:        make(map[string][]byte, 0),
 		hashProvider: sha3.NewLegacyKeccak256(),
 	}
@@ -64,7 +64,7 @@ func (vs *ValueSet) Addresses() []common.Address {
 
 // AddAddress adds an address item to the ValueSet.
 func (vs *ValueSet) AddAddress(a common.Address) {
-	vs.addresses[a] = nil
+	vs.addresses[a] = struct{}{}
 }
 
 // ContainsAddress checks if an address is contained in the ValueSet.
@@ -118,7 +118,7 @@ func (vs *ValueSet) Strings() []string {
 
 // AddString adds a string item to the ValueSet.
 func (vs *ValueSet) AddString(s string) {
-	vs.strings[s] = nil
+	vs.strings[s] = struct{}{}
 }
 
 // ContainsString checks if a string is contained in the ValueSet.


### PR DESCRIPTION
## Description

Use `reflect.TypeFor[T]()` where generic event types are known at compile time, and represent the address/string membership sets with `map[K]struct{}` instead of `map[K]any`. This makes the reflection intent explicit and avoids storing an interface value for each set member.

**Related Issues:** N/A

**Type of Change:**

- [x] Refactoring
- [x] Performance Improvement

## Testing

- `go test ./events`
- `go test ./fuzzing/valuegeneration`

## Additional Context

Membership behavior, cloned values, event keys, and public APIs are unchanged.

## Outstanding TODOs

None.