### PR TITLE
fuzzing: support disabled coverage

### DIFF
--- a/fuzzing/fuzzer_test.go
+++ b/fuzzing/fuzzer_test.go
@@ -67,6 +67,30 @@ func TestFuzzerHooks(t *testing.T) {
 	})
 }
 
+// TestFuzzerCoverageDisabled ensures a fuzzing campaign can run without coverage tracing.
+func TestFuzzerCoverageDisabled(t *testing.T) {
+	runFuzzerTest(t, &fuzzerSolcFileTest{
+		filePath: "testdata/contracts/assertions/assert_immediate.sol",
+		configUpdates: func(config *config.ProjectConfig) {
+			config.Fuzzing.TargetContracts = []string{"TestContract"}
+			config.Fuzzing.Workers = 1
+			config.Fuzzing.TestLimit = 1
+			config.Fuzzing.ShrinkLimit = 0
+			config.Fuzzing.CallSequenceLength = 1
+			config.Fuzzing.CoverageEnabled = false
+			config.Fuzzing.CoverageFormats = nil
+			config.Fuzzing.Testing.PropertyTesting.Enabled = false
+			config.Fuzzing.Testing.OptimizationTesting.Enabled = false
+			config.Slither.UseSlither = false
+		},
+		method: func(f *fuzzerTestContext) {
+			err := f.fuzzer.Start()
+			require.NoError(t, err)
+			assertFailedTestsExpected(f, true)
+		},
+	})
+}
+
 // TestSlitherPrinter runs slither and ensures that the constants are correctly added to the value set
 func TestSlitherPrinter(t *testing.T) {
 	expectedInts := []int64{

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -651,13 +651,15 @@ func (fw *FuzzerWorker) run(baseTestChain *chain.TestChain) (bool, error) {
 		return nil
 	})
 
-	// Freeze a set of `fw.deployedContracts`'s keys so that we have a set of addresses present in baseTestChain.
-	// Feed this set to the coverage tracer.
-	initialContractsSet := make(map[common.Address]struct{}, len(fw.deployedContracts))
-	for addr := range fw.deployedContracts {
-		initialContractsSet[addr] = struct{}{}
+	if fw.coverageTracer != nil {
+		// Freeze a set of `fw.deployedContracts`'s keys so that we have a set of addresses present in baseTestChain.
+		// Feed this set to the coverage tracer.
+		initialContractsSet := make(map[common.Address]struct{}, len(fw.deployedContracts))
+		for addr := range fw.deployedContracts {
+			initialContractsSet[addr] = struct{}{}
+		}
+		fw.coverageTracer.SetInitialContractsSet(&initialContractsSet)
 	}
-	fw.coverageTracer.SetInitialContractsSet(&initialContractsSet)
 
 	// If we encountered an error during cloning, return it.
 	if err != nil {


### PR DESCRIPTION
## Description

Allow fuzzing campaigns to run with coverage disabled.

Workers only create a coverage tracer when `coverageEnabled` is true, but worker startup unconditionally initialized that tracer after cloning the test chain. This caused a nil-pointer panic for the supported disabled-coverage configuration. The tracer-specific setup is now skipped when no tracer exists.

The regression test starts a real one-worker campaign with coverage and coverage reports disabled.

**Related Issues:** None

**Type of Change:**

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance Improvement
- [x] Tests
- [ ] Other (please describe):

## Testing

- `go test ./fuzzing -run '^TestFuzzerCoverageDisabled$' -count=1`
- A full `go test ./fuzzing -count=1` run was also attempted. `TestExternalLibraryDependency` fails in this local toolchain and reproduces unchanged on `master`.

## Additional Context

Coverage-enabled behavior is unchanged.

## Outstanding TODOs

None.
