### PR TITLE
chain: fix pending transaction event index

### DIFF
--- a/chain/test_chain.go
+++ b/chain/test_chain.go
@@ -787,7 +787,7 @@ func (t *TestChain) PendingBlockAddTx(message *core.Message, additionalTracers .
 	err = t.Events.PendingBlockAddedTx.Publish(PendingBlockAddedTxEvent{
 		Chain:            t,
 		Block:            t.pendingBlock,
-		TransactionIndex: len(t.pendingBlock.Messages),
+		TransactionIndex: len(t.pendingBlock.Messages) - 1,
 	})
 	if err != nil {
 		return err

--- a/chain/test_chain_test.go
+++ b/chain/test_chain_test.go
@@ -66,6 +66,50 @@ func createChain(t *testing.T) (*TestChain, []common.Address) {
 	return chain, senders
 }
 
+// TestChainPendingBlockAddedTxEventIndex ensures pending block transaction events identify the transaction and result
+// that were just added.
+func TestChainPendingBlockAddedTxEventIndex(t *testing.T) {
+	chain, senders := createChain(t)
+	block, err := chain.PendingBlockCreate()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	events := make([]PendingBlockAddedTxEvent, 0, 2)
+	chain.Events.PendingBlockAddedTx.Subscribe(func(event PendingBlockAddedTxEvent) error {
+		events = append(events, event)
+		return nil
+	})
+
+	recipient := senders[2]
+	for i := 0; i < 2; i++ {
+		message := &core.Message{
+			To:               &recipient,
+			From:             senders[i],
+			Nonce:            chain.State().GetNonce(senders[i]),
+			Value:            big.NewInt(0),
+			GasLimit:         21_000,
+			GasPrice:         big.NewInt(1),
+			GasFeeCap:        big.NewInt(0),
+			GasTipCap:        big.NewInt(0),
+			SkipNonceChecks:  false,
+			SkipFromEOACheck: false,
+		}
+
+		err = chain.PendingBlockAddTx(message)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.EqualValues(t, types.ReceiptStatusSuccessful, block.MessageResults[i].Receipt.Status)
+		if !assert.Len(t, events, i+1) || !assert.Equal(t, i, events[i].TransactionIndex) {
+			continue
+		}
+
+		assert.Same(t, message, events[i].Block.Messages[events[i].TransactionIndex])
+		assert.Same(t, block.MessageResults[i], events[i].Block.MessageResults[events[i].TransactionIndex])
+	}
+}
+
 // TestChainReverting creates a TestChain and creates blocks and later reverts backward through all possible steps
 // to ensure no error occurs and the chain state is restored.
 func TestChainReverting(t *testing.T) {

--- a/chain/test_chain_test.go
+++ b/chain/test_chain_test.go
@@ -66,50 +66,6 @@ func createChain(t *testing.T) (*TestChain, []common.Address) {
 	return chain, senders
 }
 
-// TestChainPendingBlockAddedTxEventIndex ensures pending block transaction events identify the transaction and result
-// that were just added.
-func TestChainPendingBlockAddedTxEventIndex(t *testing.T) {
-	chain, senders := createChain(t)
-	block, err := chain.PendingBlockCreate()
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	events := make([]PendingBlockAddedTxEvent, 0, 2)
-	chain.Events.PendingBlockAddedTx.Subscribe(func(event PendingBlockAddedTxEvent) error {
-		events = append(events, event)
-		return nil
-	})
-
-	recipient := senders[2]
-	for i := 0; i < 2; i++ {
-		message := &core.Message{
-			To:               &recipient,
-			From:             senders[i],
-			Nonce:            chain.State().GetNonce(senders[i]),
-			Value:            big.NewInt(0),
-			GasLimit:         21_000,
-			GasPrice:         big.NewInt(1),
-			GasFeeCap:        big.NewInt(0),
-			GasTipCap:        big.NewInt(0),
-			SkipNonceChecks:  false,
-			SkipFromEOACheck: false,
-		}
-
-		err = chain.PendingBlockAddTx(message)
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.EqualValues(t, types.ReceiptStatusSuccessful, block.MessageResults[i].Receipt.Status)
-		if !assert.Len(t, events, i+1) || !assert.Equal(t, i, events[i].TransactionIndex) {
-			continue
-		}
-
-		assert.Same(t, message, events[i].Block.Messages[events[i].TransactionIndex])
-		assert.Same(t, block.MessageResults[i], events[i].Block.MessageResults[events[i].TransactionIndex])
-	}
-}
-
 // TestChainReverting creates a TestChain and creates blocks and later reverts backward through all possible steps
 // to ensure no error occurs and the chain state is restored.
 func TestChainReverting(t *testing.T) {


### PR DESCRIPTION
## Description

Correct `PendingBlockAddedTxEvent.TransactionIndex` so it references the transaction that was just appended to the pending block. The event is published after appending the message and result, so `len(Messages)` is one past the valid index.

The regression test adds two transactions and verifies that the events expose indexes 0 and 1 together with the matching message and result.

**Related Issues:** None

**Type of Change:**

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance Improvement
- [x] Tests
- [ ] Other (please describe):

## Testing

- `go test ./chain -run '^TestChainPendingBlockAddedTxEventIndex$' -count=1`
- `go test ./chain -count=1`

## Additional Context

The event shape is unchanged. This aligns the index with the zero-based transaction references used elsewhere in the codebase.

## Outstanding TODOs

None.
