### PR TITLE
Use require() in fs test utils so setup failures halt immediately

### DIFF
--- a/utils/testutils/test_directory_utils.go
+++ b/utils/testutils/test_directory_utils.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/crytic/medusa/utils"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // CopyToTestDirectory copies files or directories from the provided filePath (relative to ./tests/contracts/) to an
@@ -14,13 +14,14 @@ import (
 func CopyToTestDirectory(t *testing.T, filePath string) string {
 	// Construct our file path relative to our working directory
 	cwd, err := os.Getwd()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	sourcePath := filepath.Join(cwd, filePath)
 
-	// Verify the file path exists
+	// Verify the file path exists. A missing source path must halt the test
+	// immediately: continuing would dereference a nil sourcePathInfo below.
 	sourcePathInfo, err := os.Stat(sourcePath)
-	assert.False(t, os.IsNotExist(err))
-	assert.NotNil(t, sourcePathInfo)
+	require.NoError(t, err)
+	require.NotNil(t, sourcePathInfo)
 
 	// Obtain an isolated test directory path.
 	targetDirectory := filepath.Join(t.TempDir(), "medusaTest")
@@ -31,11 +32,11 @@ func CopyToTestDirectory(t *testing.T, filePath string) string {
 	} else {
 		err = utils.CopyFile(sourcePath, targetPath)
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get a normalized absolute path
 	targetPath, err = filepath.Abs(targetPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return targetPath
 }
 
@@ -45,12 +46,13 @@ func CopyToTestDirectory(t *testing.T, filePath string) string {
 func ExecuteInDirectory(t *testing.T, testPath string, method func()) {
 	// Backup our old working directory
 	cwd, err := os.Getwd()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check if the test path refers to a file or directory, as we'll want to change our working directory to a
-	// directory path.
+	// directory path. A missing test path must halt the test immediately: continuing would
+	// dereference a nil testPathInfo below.
 	testPathInfo, err := os.Stat(testPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Ensure we obtained a directory from our path
 	testDirectory := testPath
@@ -60,12 +62,12 @@ func ExecuteInDirectory(t *testing.T, testPath string, method func()) {
 
 	// Change our working directory to the test directory
 	err = os.Chdir(testDirectory)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Execute the given method
 	method()
 
 	// Restore our working directory (we must leave the test directory or else clean up will fail post testing)
 	err = os.Chdir(cwd)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Fixes #86

`CopyToTestDirectory` and `ExecuteInDirectory` are test-setup helpers: when a source/test path is missing, they recorded an `assert` failure and then **continued executing**, panicking on the very next line — exactly the behavior described in #86 (`sourcePathInfo.Name()` dereferences a nil `sourcePathInfo`, and `testPathInfo.IsDir()` in `ExecuteInDirectory` has the same shape).

This switches the setup checks to testify `require.*` so the test stops at the real failure:

- `os.Getwd()` errors (both helpers — continuing would operate on an empty cwd)
- `os.Stat()` errors for the source/test path (**the panic paths**)
- `CopyDirectory` / `CopyFile` results (continuing would return a path to a missing file)
- `filepath.Abs` and `os.Chdir` results

No behavior change on the happy path — `require` and `assert` share identical call signatures here; only the failure semantics change (immediate stop vs. continue-then-panic).

### Verification
- `gofmt -l utils/testutils/` — clean
- `go vet ./utils/testutils/` — clean
- `go test ./utils/testutils/` — compiles and passes (no test files in the package; helpers only)
