### PR TITLE
compilation: separate Slither output streams

### DIFF
--- a/compilation/types/slither.go
+++ b/compilation/types/slither.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/crytic/medusa/logging"
+	"github.com/crytic/medusa/utils"
 )
 
 // SlitherConfig determines whether to run slither and whether and where to cache the results from slither
@@ -130,9 +131,9 @@ func (s *SlitherConfig) RunSlither(target string, solcVersion string) (*SlitherR
 			cmd.Env = append(os.Environ(), fmt.Sprintf("SOLC_VERSION=%s", solcVersion))
 		}
 
-		// Run slither
+		// Run slither while keeping diagnostics separate from the JSON output.
 		start := time.Now()
-		out, err = cmd.CombinedOutput()
+		out, err = runSlitherCommand(cmd)
 		if err != nil {
 			return nil, err
 		}
@@ -164,6 +165,15 @@ func (s *SlitherConfig) RunSlither(target string, solcVersion string) (*SlitherR
 	}
 
 	return &slitherResults, nil
+}
+
+// runSlitherCommand runs Slither and returns only stdout so stderr diagnostics cannot corrupt its JSON output.
+func runSlitherCommand(cmd *exec.Cmd) ([]byte, error) {
+	stdout, _, combined, err := utils.RunCommandWithOutputAndError(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("error while executing slither: %w\n\nCommand Output:\n%s", err, string(combined))
+	}
+	return stdout, nil
 }
 
 // UnmarshalJSON unmarshals the slither output into a SlitherResults type

--- a/compilation/types/slither_test.go
+++ b/compilation/types/slither_test.go
@@ -1,0 +1,68 @@
+package types
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunSlitherCommandIgnoresStderr verifies diagnostics do not contaminate Slither's JSON output.
+func TestRunSlitherCommandIgnoresStderr(t *testing.T) {
+	stdout := `{"success":true,"error":"","results":{"printers":[{"description":"{\"constants_used\":{}}"}]}}`
+	cmd := newSlitherHelperCommand(t, stdout, "compiler warning\n", 0)
+
+	out, err := runSlitherCommand(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, stdout, string(out))
+
+	var results SlitherResults
+	require.NoError(t, results.UnmarshalJSON(out))
+	assert.Empty(t, results.Constants)
+}
+
+// TestRunSlitherCommandReportsStderr verifies command diagnostics remain available when Slither fails.
+func TestRunSlitherCommandReportsStderr(t *testing.T) {
+	cmd := newSlitherHelperCommand(t, "", "slither failed to compile\n", 1)
+
+	_, err := runSlitherCommand(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slither failed to compile")
+}
+
+// newSlitherHelperCommand creates a cross-platform subprocess that emits controlled output for command tests.
+func newSlitherHelperCommand(t *testing.T, stdout string, stderr string, exitCode int) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSlitherHelperProcess$")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_SLITHER_HELPER_PROCESS=1",
+		"SLITHER_HELPER_STDOUT="+stdout,
+		"SLITHER_HELPER_STDERR="+stderr,
+		"SLITHER_HELPER_EXIT_CODE="+strconv.Itoa(exitCode),
+	)
+	return cmd
+}
+
+// TestSlitherHelperProcess emits subprocess output configured by newSlitherHelperCommand.
+func TestSlitherHelperProcess(t *testing.T) {
+	// Return immediately when this test is not running as a helper subprocess.
+	if os.Getenv("GO_WANT_SLITHER_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	// Write the configured values to their respective process streams.
+	_, _ = fmt.Fprint(os.Stdout, os.Getenv("SLITHER_HELPER_STDOUT"))
+	_, _ = fmt.Fprint(os.Stderr, os.Getenv("SLITHER_HELPER_STDERR"))
+
+	// Exit with the configured status so callers can exercise success and failure paths.
+	exitCode, err := strconv.Atoi(os.Getenv("SLITHER_HELPER_EXIT_CODE"))
+	if err != nil {
+		_, _ = fmt.Fprint(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
## Description

Separates Slither's stdout and stderr so stderr warnings do not corrupt the JSON output. Command diagnostics are still included when Slither exits with an error.

Adds regression tests for successful JSON output with stderr warnings and for preserving stderr when the command fails.

**Related Issues:** Closes #833

**Type of Change:**

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance Improvement
- [x] Tests
- [ ] Other (please describe):

## Testing

- `go test -v ./compilation/types`
- `go test -race ./compilation/types`
- `go vet ./compilation/types`
- `golangci-lint run --timeout 5m0s`
- `go test ./...` in a Linux amd64 container with the CI dependencies installed

## Additional Context

None.

## Outstanding TODOs

None.