### PR TITLE
ci: fix lint job and modernize Go and golangci-lint versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ defaults:
 permissions:
   contents: read
 
+env:
+  # Bounded to a minor line so a new Go release cannot silently change what CI
+  # runs. golangci-lint only supports toolchains up to the Go version it was
+  # built with, so raising this may require raising GOLANGCI_LINT_VERSION too.
+  GO_VERSION: "1.26"
+  GOLANGCI_LINT_VERSION: v2.12.2
+
 jobs:
   build:
     needs: [lint]
@@ -56,7 +63,7 @@ jobs:
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "^1.22"
+          go-version: ${{ env.GO_VERSION }}
           # disable caching during release (tag) builds
           cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
@@ -128,6 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    env:
+      ACTIONLINT_VERSION: v1.7.12
+
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
@@ -135,18 +145,18 @@ jobs:
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "^1.22"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Cache actionlint
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/go/bin/actionlint
-          key: actionlint-${{ runner.os }}
+          key: actionlint-${{ runner.os }}-${{ env.ACTIONLINT_VERSION }}
 
       - name: Actionlint
         run: |
           if [ ! -f ~/go/bin/actionlint ]; then
-            go install github.com/rhysd/actionlint/cmd/actionlint@latest
+            go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
           fi
           actionlint
 
@@ -170,10 +180,11 @@ jobs:
           git diff --exit-code
 
       - name: Lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v1.64.8
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout 5m0s
+
   test:
     strategy:
       matrix:
@@ -213,7 +224,7 @@ jobs:
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "^1.22"
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      # Upstream go-ethereum code, kept close to its original form so it can be
+      # diffed against and re-synced. Style findings here are not ours to fix.
+      - path: chain/vendored/
+        linters:
+          - staticcheck

--- a/chain/state/cache/caches_test.go
+++ b/chain/state/cache/caches_test.go
@@ -119,7 +119,7 @@ func TestPersistentCache(t *testing.T) {
 	blockHeight := uint64(55555)
 	tmpDir, err := os.MkdirTemp("", "test-*")
 	assert.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	pc, err := newPersistentCache(ctx, tmpDir, rpcAddr, blockHeight)
 	assert.NoError(t, err)

--- a/chain/test_chain.go
+++ b/chain/test_chain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 
 	"github.com/crytic/medusa/chain/state"
@@ -15,7 +16,6 @@ import (
 	"github.com/crytic/medusa-geth/triedb/hashdb"
 	"github.com/crytic/medusa/chain/config"
 	"github.com/holiman/uint256"
-	"golang.org/x/exp/maps"
 
 	"github.com/crytic/medusa-geth/common"
 	"github.com/crytic/medusa-geth/common/math"
@@ -266,8 +266,10 @@ func newTestChainWithStateFactory(
 // must be explicitly released is the stateDB trie's underlying cache. This cache, if not released, prevents the TestChain
 // object from being freed by the garbage collector and causes a severe memory leak.
 func (t *TestChain) Close() {
-	// Reset the state DB's cache
-	t.stateDatabase.TrieDB().Close()
+	// Reset the state DB's cache. Every caller invokes this from a defer during
+	// teardown and has no recovery path, so the close error is dropped here rather
+	// than widening the signature to one that callers would discard anyway.
+	_ = t.stateDatabase.TrieDB().Close()
 }
 
 // Clone recreates the current TestChain state into a new instance. This simply reconstructs the block/chain state
@@ -538,7 +540,7 @@ func (t *TestChain) CallContract(msg *core.Message, state types.MedusaStateDB, a
 
 	// Create our EVM instance.
 	evm := vm.NewEVM(blockContext, state, t.chainConfig, vm.Config{
-		Tracer:           extendedTracerRouter.NativeTracer().Tracer.Hooks,
+		Tracer:           extendedTracerRouter.NativeTracer().Hooks,
 		NoBaseFee:        true,
 		ConfigExtensions: t.vmConfigExtensions,
 	})
@@ -739,7 +741,7 @@ func (t *TestChain) PendingBlockAddTx(message *core.Message, additionalTracers .
 	}
 
 	// Update the VM's tracer
-	vmConfig.Tracer = extendedTracerRouter.NativeTracer().Tracer.Hooks
+	vmConfig.Tracer = extendedTracerRouter.NativeTracer().Hooks
 
 	// Set tx context
 	t.state.SetTxContext(tx.Hash(), len(t.pendingBlock.Messages))

--- a/chain/types/generic_hooks.go
+++ b/chain/types/generic_hooks.go
@@ -1,6 +1,6 @@
 package types
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 // GenericHookFunc defines a basic function that takes no arguments and returns none, to be used as a hook during
 // execution.

--- a/cmd/exitcodes/error_with_exit_code.go
+++ b/cmd/exitcodes/error_with_exit_code.go
@@ -26,16 +26,16 @@ func (e *ErrorWithExitCode) Error() string {
 // GetInnerErrorAndExitCode checks the given exit code that the application should exit with, if this error is bubbled
 // to the top-level. This will be 0 for a nil error, 1 for a generic error, or arbitrary if the error is of type
 // ErrorWithExitCode.
-// Returns the error (or inner error if it is an ErrorWithExitCode error type), along with the exit code associated
-// with the error.
-func GetInnerErrorAndExitCode(err error) (error, int) {
+// Returns the exit code associated with the error, along with the error itself (or inner error if it is an
+// ErrorWithExitCode error type).
+func GetInnerErrorAndExitCode(err error) (int, error) {
 	// If we have no error, return 0, if we have a generic error, return 1, if we have a custom error code, unwrap
 	// and return it.
 	if err == nil {
-		return nil, ExitCodeSuccess
+		return ExitCodeSuccess, nil
 	} else if unwrappedErr, ok := err.(*ErrorWithExitCode); ok {
-		return unwrappedErr.err, unwrappedErr.exitCode
+		return unwrappedErr.exitCode, unwrappedErr.err
 	} else {
-		return err, ExitCodeGeneralError
+		return ExitCodeGeneralError, err
 	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -77,8 +77,8 @@ func cmdValidInitArgs(cmd *cobra.Command, args []string, toComplete string) ([]s
 func cmdValidateInitArgs(cmd *cobra.Command, args []string) error {
 	// Make sure we have no more than 1 arg
 	if err := cobra.RangeArgs(0, 1)(cmd, args); err != nil {
-		err = fmt.Errorf("init accepts at most 1 platform argument (options: %s). "+
-			"default platform is %v\n", strings.Join(supportedPlatforms, ", "), DefaultCompilationPlatform)
+		err = fmt.Errorf("init accepts at most 1 platform argument (options: %s), "+
+			"default platform is %v", strings.Join(supportedPlatforms, ", "), DefaultCompilationPlatform)
 		cmdLogger.Error("Failed to validate args to the init command", err)
 		return err
 	}

--- a/compilation/platforms/crytic_compile.go
+++ b/compilation/platforms/crytic_compile.go
@@ -129,7 +129,7 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 			// the solc version was not installed
 			out, err := exec.Command("solc-select", "install", c.SolcVersion).CombinedOutput()
 			if err != nil {
-				return nil, "", fmt.Errorf("error while executing `solc-select install`:\nOUTPUT:\n%s\nERROR: %s\n", string(out), err.Error())
+				return nil, "", fmt.Errorf("error while executing `solc-select install`:\nOUTPUT:\n%s\nERROR: %s", string(out), err.Error())
 			}
 		}
 	}
@@ -137,7 +137,7 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 	// Run crytic-compile to compile and export our compilation artifacts.
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, "", fmt.Errorf("error while executing crytic-compile:\nOUTPUT:\n%s\nERROR: %s\n", string(out), err.Error())
+		return nil, "", fmt.Errorf("error while executing crytic-compile:\nOUTPUT:\n%s\nERROR: %s", string(out), err.Error())
 	}
 
 	// Find compilation artifacts in the export directory
@@ -242,7 +242,7 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 			// Parse the ABI
 			contractAbi, err := types.ParseABIFromInterface(contract.Abi)
 			if err != nil {
-				return nil, "", fmt.Errorf("unable to parse ABI for contract '%s'\n", contractName)
+				return nil, "", fmt.Errorf("unable to parse ABI for contract '%s'", contractName)
 			}
 
 			initBytecode := []byte(contract.Bin)
@@ -251,12 +251,12 @@ func (c *CryticCompilationConfig) Compile() ([]types.Compilation, string, error)
 			if len(libraryPlaceholders) == 0 {
 				initBytecode, err = hex.DecodeString(strings.TrimPrefix(contract.Bin, "0x"))
 				if err != nil {
-					return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'\n", contractName)
+					return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'", contractName)
 				}
 
 				runtimeBytecode, err = hex.DecodeString(strings.TrimPrefix(contract.BinRuntime, "0x"))
 				if err != nil {
-					return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'\n", contractName)
+					return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'", contractName)
 				}
 			}
 

--- a/compilation/platforms/solc.go
+++ b/compilation/platforms/solc.go
@@ -43,7 +43,7 @@ func GetSystemSolcVersion() (*semver.Version, error) {
 	// Run solc --version to obtain our compiler version.
 	out, err := exec.Command("solc", "--version").CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("error while executing solc:\nOUTPUT:\n%s\nERROR: %s\n", string(out), err.Error())
+		return nil, fmt.Errorf("error while executing solc:\nOUTPUT:\n%s\nERROR: %s", string(out), err.Error())
 	}
 
 	// Parse the compiler version out of the output
@@ -92,7 +92,7 @@ func (s *SolcCompilationConfig) Compile() ([]types.Compilation, string, error) {
 	cmd := exec.Command("solc", s.Target, "--combined-json", outputOptions)
 	cmdStdout, cmdStderr, cmdCombined, err := utils.RunCommandWithOutputAndError(cmd)
 	if err != nil {
-		return nil, "", fmt.Errorf("error while executing solc:\n%s\n\nCommand Output:\n%s\n", err.Error(), string(cmdCombined))
+		return nil, "", fmt.Errorf("error while executing solc:\n%s\n\nCommand Output:\n%s", err.Error(), string(cmdCombined))
 	}
 
 	// Our compilation succeeded, load the JSON
@@ -184,11 +184,11 @@ func (s *SolcCompilationConfig) Compile() ([]types.Compilation, string, error) {
 		if len(libraryPlaceholders) == 0 {
 			initBytecode, err = hex.DecodeString(strings.TrimPrefix(contract.Code, "0x"))
 			if err != nil {
-				return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'\n", contractName)
+				return nil, "", fmt.Errorf("unable to parse init bytecode for contract '%s'", contractName)
 			}
 			runtimeBytecode, err = hex.DecodeString(strings.TrimPrefix(contract.RuntimeCode, "0x"))
 			if err != nil {
-				return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'\n", contractName)
+				return nil, "", fmt.Errorf("unable to parse runtime bytecode for contract '%s'", contractName)
 			}
 		}
 

--- a/compilation/types/compiled_contract.go
+++ b/compilation/types/compiled_contract.go
@@ -170,13 +170,13 @@ func (c *CompiledContract) LinkBytecodes(contractName string, deployedLibraries 
 	// Decode into hex string
 	initBytecode, err := c.DecodeLinkedInitBytecodeBytes()
 	if err != nil {
-		panic(fmt.Errorf("unable to parse init bytecode for contract %s \n", contractName))
+		panic(fmt.Errorf("unable to parse init bytecode for contract %s", contractName))
 	}
 
 	// Decode into a hex string
 	runtimeBytecode, err := c.DecodeLinkedRuntimeBytecodeBytes()
 	if err != nil {
-		panic(fmt.Errorf("unable to parse runtime bytecode for contract %s \n", contractName))
+		panic(fmt.Errorf("unable to parse runtime bytecode for contract %s", contractName))
 	}
 	c.InitBytecode = initBytecode
 	c.RuntimeBytecode = runtimeBytecode

--- a/compilation/types/slither.go
+++ b/compilation/types/slither.go
@@ -158,7 +158,7 @@ func (s *SlitherConfig) RunSlither(target string, solcVersion string) (*SlitherR
 			if _, err = os.Stat(s.CachePath); err == nil {
 				// We will not handle the error of os.Remove since we have already checked for the file's existence
 				// and we have the right permissions.
-				os.Remove(s.CachePath)
+				_ = os.Remove(s.CachePath)
 			}
 		}
 	}

--- a/fuzzing/calls/call_sequence.go
+++ b/fuzzing/calls/call_sequence.go
@@ -252,11 +252,12 @@ func (cse *CallSequenceElement) String() string {
 	methodName := "<unresolved method>"
 	if err == nil && method != nil {
 		// Special handlers for fallback and receive
-		if method.Type == abi.Fallback {
+		switch method.Type {
+		case abi.Fallback:
 			methodName = "fallback"
-		} else if method.Type == abi.Receive {
+		case abi.Receive:
 			methodName = "receive"
-		} else {
+		default:
 			methodName = method.Sig
 		}
 	}

--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -133,13 +133,13 @@ func (cb *ContractBalance) UnmarshalJSON(data []byte) error {
 
 	// Empty string handling
 	if s == "" {
-		cb.Int.SetInt64(0)
+		cb.SetInt64(0)
 		return nil
 	}
 
 	// Hex notation handling
 	if strings.HasPrefix(strings.ToLower(s), "0x") {
-		if _, ok := cb.Int.SetString(s[2:], 16); !ok {
+		if _, ok := cb.SetString(s[2:], 16); !ok {
 			return fmt.Errorf("invalid hex string provided while unmarshaling contract balance: %s", s)
 		}
 		return nil
@@ -152,14 +152,14 @@ func (cb *ContractBalance) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("error parsing scientific notation while unmarshaling contract balance: %w", err)
 		}
 		plainStr := strconv.FormatFloat(f, 'f', 0, 64)
-		if _, ok := cb.Int.SetString(plainStr, 10); !ok {
+		if _, ok := cb.SetString(plainStr, 10); !ok {
 			return fmt.Errorf("invalid format for contract balance (scientific notation) while unmarshaling contract balance: %s", s)
 		}
 		return nil
 	}
 
 	// Base-10 string handling
-	if _, ok := cb.Int.SetString(s, 10); !ok {
+	if _, ok := cb.SetString(s, 10); !ok {
 		return fmt.Errorf("invalid base-10 string provided while unmarshaling contract balance: %s", s)
 	}
 	return nil
@@ -167,7 +167,7 @@ func (cb *ContractBalance) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON marshals a ContractBalance to JSON.
 func (cb ContractBalance) MarshalJSON() ([]byte, error) {
-	return json.Marshal(cb.Int.String())
+	return json.Marshal(cb.String())
 }
 
 // VerbosityLevel defines different verbosity levels

--- a/fuzzing/coverage/source_analysis.go
+++ b/fuzzing/coverage/source_analysis.go
@@ -2,17 +2,19 @@ package coverage
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/crytic/medusa-geth/core/vm"
 	"github.com/crytic/medusa/compilation/types"
 	"github.com/crytic/medusa/logging"
-	"golang.org/x/exp/maps"
 )
 
 // SourceAnalysis describes source code coverage across a list of compilations, after analyzing associated CoverageMaps.
@@ -24,11 +26,11 @@ type SourceAnalysis struct {
 // SortedFiles returns a list of Files within the SourceAnalysis, sorted by source file path in alphabetical order.
 func (s *SourceAnalysis) SortedFiles() []*SourceFileAnalysis {
 	// Copy all source files from our analysis into a list.
-	sourceFiles := maps.Values(s.Files)
+	sourceFiles := slices.Collect(maps.Values(s.Files))
 
 	// Sort source files by path
-	sort.Slice(sourceFiles, func(x, y int) bool {
-		return sourceFiles[x].Path < sourceFiles[y].Path
+	slices.SortFunc(sourceFiles, func(x, y *SourceFileAnalysis) int {
+		return cmp.Compare(x.Path, y.Path)
 	})
 
 	return sourceFiles
@@ -115,15 +117,15 @@ func (s *SourceAnalysis) GenerateLCOVReport() string {
 	buffer.WriteString("TN:\n")
 	for _, file := range s.SortedFiles() {
 		// SF:<path to the source file>
-		buffer.WriteString(fmt.Sprintf("SF:%s\n", file.Path))
+		fmt.Fprintf(&buffer, "SF:%s\n", file.Path)
 		for idx, line := range file.Lines {
 			if line.IsActive {
 				// DA:<line number>,<execution count>
 				if line.IsCovered {
-					buffer.WriteString(fmt.Sprintf("DA:%d,%d\n", idx+1, line.SuccessHitCount))
+					fmt.Fprintf(&buffer, "DA:%d,%d\n", idx+1, line.SuccessHitCount)
 					linesHit++
 				} else {
-					buffer.WriteString(fmt.Sprintf("DA:%d,%d\n", idx+1, 0))
+					fmt.Fprintf(&buffer, "DA:%d,%d\n", idx+1, 0)
 				}
 				linesInstrumented++
 			}
@@ -153,8 +155,8 @@ func (s *SourceAnalysis) GenerateLCOVReport() string {
 
 			// TODO: handle fallback, receive, and constructor
 			if fn.Name != "" {
-				buffer.WriteString(fmt.Sprintf("FN:%d,%s\n", startLine, fn.Name))
-				buffer.WriteString(fmt.Sprintf("FNDA:%d,%s\n", hit, fn.Name))
+				fmt.Fprintf(&buffer, "FN:%d,%s\n", startLine, fn.Name)
+				fmt.Fprintf(&buffer, "FNDA:%d,%s\n", hit, fn.Name)
 			}
 
 		}
@@ -610,7 +612,7 @@ func filterSourceMaps(compilation types.Compilation, sourceMap types.SourceMap) 
 		encapsulatesOtherMapping := false
 		for x, sourceMapElement2 := range sourceMap {
 			if i != x && sourceMapElement.SourceUnitID == sourceMapElement2.SourceUnitID &&
-				!(sourceMapElement.Offset == sourceMapElement2.Offset && sourceMapElement.Length == sourceMapElement2.Length) {
+				(sourceMapElement.Offset != sourceMapElement2.Offset || sourceMapElement.Length != sourceMapElement2.Length) {
 				if sourceMapElement2.Offset >= sourceMapElement.Offset &&
 					sourceMapElement2.Offset+sourceMapElement2.Length <= sourceMapElement.Offset+sourceMapElement.Length {
 					encapsulatesOtherMapping = true

--- a/fuzzing/reverts/revert_reporter.go
+++ b/fuzzing/reverts/revert_reporter.go
@@ -174,10 +174,8 @@ func (r *RevertReporter) writeHTMLReport() error {
 	path := filepath.Join(r.Path, "revert_report.html")
 	file, err := os.Create(path)
 	if err != nil {
-		_ = file.Close()
 		return fmt.Errorf("failed to open HTML revert report for writing: %v", err)
 	}
-	defer file.Close()
 
 	functionMap := template.FuncMap{
 		"timeNow": time.Now,
@@ -251,10 +249,17 @@ func (r *RevertReporter) writeHTMLReport() error {
 
 	tmpl, err := template.New("revert_report.html").Funcs(functionMap).Parse(string(htmlReportTemplate))
 	if err != nil {
+		_ = file.Close()
 		return fmt.Errorf("failed to parse HTML revert report template: %v", err)
 	}
 
+	// Close reports buffered writes that failed to flush, so a truncated report
+	// is surfaced rather than logged as a success.
 	err = tmpl.Execute(file, r.RevertMetrics)
+	fileCloseErr := file.Close()
+	if err == nil {
+		err = fileCloseErr
+	}
 	if err != nil {
 		return fmt.Errorf("failed to write HTML revert report at %v: %v", path, err)
 	}

--- a/fuzzing/test_case_assertion.go
+++ b/fuzzing/test_case_assertion.go
@@ -65,5 +65,5 @@ func (t *AssertionTestCase) Message() string {
 
 // ID obtains a unique identifier for a test result.
 func (t *AssertionTestCase) ID() string {
-	return strings.Replace(fmt.Sprintf("ASSERTION-%s-%s", t.targetContract.Name(), t.targetMethod.Sig), "_", "-", -1)
+	return strings.ReplaceAll(fmt.Sprintf("ASSERTION-%s-%s", t.targetContract.Name(), t.targetMethod.Sig), "_", "-")
 }

--- a/fuzzing/test_case_optimization.go
+++ b/fuzzing/test_case_optimization.go
@@ -99,7 +99,7 @@ func (t *OptimizationTestCase) Message() string {
 
 // ID obtains a unique identifier for a test result.
 func (t *OptimizationTestCase) ID() string {
-	return strings.Replace(fmt.Sprintf("OPTIMIZATION-%s-%s", t.targetContract.Name(), t.targetMethod.Sig), "_", "-", -1)
+	return strings.ReplaceAll(fmt.Sprintf("OPTIMIZATION-%s-%s", t.targetContract.Name(), t.targetMethod.Sig), "_", "-")
 }
 
 // Value obtains the maximum value returned by the test method found till now

--- a/fuzzing/test_case_property.go
+++ b/fuzzing/test_case_property.go
@@ -73,5 +73,5 @@ func (t *PropertyTestCase) Message() string {
 
 // ID obtains a unique identifier for a test result.
 func (t *PropertyTestCase) ID() string {
-	return strings.Replace(fmt.Sprintf("PROPERTY-%s-%s", t.targetContract.Name(), t.targetMethod.Sig), "_", "-", -1)
+	return strings.ReplaceAll(fmt.Sprintf("PROPERTY-%s-%s", t.targetContract.Name(), t.targetMethod.Sig), "_", "-")
 }

--- a/fuzzing/valuegeneration/abi_values.go
+++ b/fuzzing/valuegeneration/abi_values.go
@@ -28,27 +28,29 @@ func GenerateAbiValue(generator ValueGenerator, inputType *abi.Type) any {
 	case abi.AddressTy:
 		return generator.GenerateAddress()
 	case abi.UintTy:
-		if inputType.Size == 64 {
+		switch inputType.Size {
+		case 64:
 			return generator.GenerateInteger(false, inputType.Size).Uint64()
-		} else if inputType.Size == 32 {
+		case 32:
 			return uint32(generator.GenerateInteger(false, inputType.Size).Uint64())
-		} else if inputType.Size == 16 {
+		case 16:
 			return uint16(generator.GenerateInteger(false, inputType.Size).Uint64())
-		} else if inputType.Size == 8 {
+		case 8:
 			return uint8(generator.GenerateInteger(false, inputType.Size).Uint64())
-		} else {
+		default:
 			return generator.GenerateInteger(false, inputType.Size)
 		}
 	case abi.IntTy:
-		if inputType.Size == 64 {
+		switch inputType.Size {
+		case 64:
 			return generator.GenerateInteger(true, inputType.Size).Int64()
-		} else if inputType.Size == 32 {
+		case 32:
 			return int32(generator.GenerateInteger(true, inputType.Size).Int64())
-		} else if inputType.Size == 16 {
+		case 16:
 			return int16(generator.GenerateInteger(true, inputType.Size).Int64())
-		} else if inputType.Size == 8 {
+		case 8:
 			return int8(generator.GenerateInteger(true, inputType.Size).Int64())
-		} else {
+		default:
 			return generator.GenerateInteger(true, inputType.Size)
 		}
 	case abi.BoolTy:
@@ -115,31 +117,32 @@ func MutateAbiValue(generator ValueGenerator, mutator ValueMutator, inputType *a
 		}
 		return mutator.MutateAddress(addr), nil
 	case abi.UintTy:
-		if inputType.Size == 64 {
+		switch inputType.Size {
+		case 64:
 			v, ok := value.(uint64)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate uint%v input as the value provided is not of the correct type", inputType.Size)
 			}
 			return mutator.MutateInteger(new(big.Int).SetUint64(v), false, inputType.Size).Uint64(), nil
-		} else if inputType.Size == 32 {
+		case 32:
 			v, ok := value.(uint32)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate uint%v input as the value provided is not of the correct type", inputType.Size)
 			}
 			return uint32(mutator.MutateInteger(new(big.Int).SetUint64(uint64(v)), false, inputType.Size).Uint64()), nil
-		} else if inputType.Size == 16 {
+		case 16:
 			v, ok := value.(uint16)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate uint%v input as the value provided is not of the correct type", inputType.Size)
 			}
 			return uint16(mutator.MutateInteger(new(big.Int).SetUint64(uint64(v)), false, inputType.Size).Uint64()), nil
-		} else if inputType.Size == 8 {
+		case 8:
 			v, ok := value.(uint8)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate uint%v input as the value provided is not of the correct type", inputType.Size)
 			}
 			return uint8(mutator.MutateInteger(new(big.Int).SetUint64(uint64(v)), false, inputType.Size).Uint64()), nil
-		} else {
+		default:
 			v, ok := value.(*big.Int)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate uint%v input as the value provided is not of the correct type", inputType.Size)
@@ -147,31 +150,32 @@ func MutateAbiValue(generator ValueGenerator, mutator ValueMutator, inputType *a
 			return mutator.MutateInteger(new(big.Int).Set(v), false, inputType.Size), nil
 		}
 	case abi.IntTy:
-		if inputType.Size == 64 {
+		switch inputType.Size {
+		case 64:
 			v, ok := value.(int64)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate int%v input as the value provided is not of the correct type", inputType.Size)
 			}
 			return mutator.MutateInteger(new(big.Int).SetInt64(v), true, inputType.Size).Int64(), nil
-		} else if inputType.Size == 32 {
+		case 32:
 			v, ok := value.(int32)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate int%v input as the value provided is not of the correct type", inputType.Size)
 			}
 			return int32(mutator.MutateInteger(new(big.Int).SetInt64(int64(v)), true, inputType.Size).Int64()), nil
-		} else if inputType.Size == 16 {
+		case 16:
 			v, ok := value.(int16)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate int%v input as the value provided is not of the correct type", inputType.Size)
 			}
 			return int16(mutator.MutateInteger(new(big.Int).SetInt64(int64(v)), true, inputType.Size).Int64()), nil
-		} else if inputType.Size == 8 {
+		case 8:
 			v, ok := value.(int8)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate int%v input as the value provided is not of the correct type", inputType.Size)
 			}
 			return int8(mutator.MutateInteger(new(big.Int).SetInt64(int64(v)), true, inputType.Size).Int64()), nil
-		} else {
+		default:
 			v, ok := value.(*big.Int)
 			if !ok {
 				return nil, fmt.Errorf("could not mutate int%v input as the value provided is not of the correct type", inputType.Size)
@@ -739,7 +743,7 @@ func decodeJSONArgument(inputType *abi.Type, value any, deployedContractAddr map
 				return nil, fmt.Errorf("contract %s not found in deployed contracts", contractName)
 			}
 		} else {
-			if !((len(str) == (common.AddressLength*2 + 2)) || (len(str) == common.AddressLength*2)) {
+			if len(str) != common.AddressLength*2+2 && len(str) != common.AddressLength*2 {
 				err := fmt.Errorf("invalid address length (%v)", len(str))
 				return nil, err
 			}

--- a/fuzzing/valuegeneration/generator_mutational.go
+++ b/fuzzing/valuegeneration/generator_mutational.go
@@ -428,7 +428,7 @@ func (g *MutationalValueGenerator) MutateBool(bl bool) bool {
 	// Determine whether to perform mutations against this input or just return it as-is.
 	randomGeneratorDecision := g.randomProvider.Float32()
 	if randomGeneratorDecision < g.config.MutateBoolProbability {
-		return g.RandomValueGenerator.GenerateBool()
+		return g.GenerateBool()
 	}
 	return bl
 }

--- a/fuzzing/valuegeneration/value_set_from_ast.go
+++ b/fuzzing/valuegeneration/value_set_from_ast.go
@@ -30,7 +30,8 @@ func (vs *ValueSet) SeedFromAst(ast any) {
 			}
 
 			// Seed ValueSet with literals
-			if literalKind == "number" {
+			switch literalKind {
+			case "number":
 				// If it has a 0x prefix, it won't have decimals
 				if strings.HasPrefix(literalValue, "0x") {
 					if b, ok := big.NewInt(0).SetString(literalValue[2:], 16); ok {
@@ -46,7 +47,7 @@ func (vs *ValueSet) SeedFromAst(ast any) {
 						vs.AddAddress(common.BigToAddress(b))
 					}
 				}
-			} else if literalKind == "string" {
+			case "string":
 				vs.AddString(literalValue)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -13,8 +13,7 @@ func main() {
 	err := cmd.Execute()
 
 	// Obtain the actual error and exit code from the error, if any.
-	var exitCode int
-	err, exitCode = exitcodes.GetInnerErrorAndExitCode(err)
+	exitCode, err := exitcodes.GetInnerErrorAndExitCode(err)
 
 	// If we have an error, print it.
 	if err != nil && exitCode != exitcodes.ExitCodeHandledError {

--- a/utils/fs_utils.go
+++ b/utils/fs_utils.go
@@ -56,22 +56,27 @@ func CopyFile(sourcePath string, targetPath string) error {
 		return err
 	}
 
-	// Open a handle to the source file
+	// Open a handle to the source file. This handle is only read from, so a failure
+	// to close it cannot lose data.
 	sourceFile, err := os.Open(sourcePath)
 	if err != nil {
 		return err
 	}
-	defer sourceFile.Close()
+	defer func() { _ = sourceFile.Close() }()
 
 	// Get a handle to the created target file
 	targetFile, err := os.Create(targetPath)
 	if err != nil {
 		return err
 	}
-	defer targetFile.Close()
 
-	// Copy contents from one file handle to the other
+	// Copy contents from one file handle to the other. Close reports buffered writes
+	// that failed to flush, so a truncated copy is not reported as a success.
 	_, err = io.Copy(targetFile, sourceFile)
+	targetCloseErr := targetFile.Close()
+	if err == nil {
+		err = targetCloseErr
+	}
 	if err != nil {
 		return err
 	}
@@ -142,7 +147,7 @@ func MakeDirectory(dirToMake string) error {
 
 	// dirToMake is a file, throw an error accordingly
 	if !dirInfo.IsDir() {
-		return fmt.Errorf("there is a file with the same name as %s\n", dirInfo)
+		return fmt.Errorf("there is a file with the same name as %s", dirInfo)
 	}
 
 	// Directory already exists, good to go

--- a/utils/integer_utils.go
+++ b/utils/integer_utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"cmp"
 	"math/big"
 
 	"golang.org/x/exp/constraints"
@@ -95,7 +96,7 @@ func Abs[T constraints.Integer](x T) T {
 
 // Min provides generic support for various integer types to be compared and the minimum of two values returned.
 // Returns the minimum of the two values provided.
-func Min[T constraints.Ordered](x T, y T) T {
+func Min[T cmp.Ordered](x T, y T) T {
 	if x <= y {
 		return x
 	}
@@ -104,7 +105,7 @@ func Min[T constraints.Ordered](x T, y T) T {
 
 // Max provides generic support for various integer types to be compared and the maximum of two values returned.
 // Returns the maximum of the two values provided.
-func Max[T constraints.Ordered](x T, y T) T {
+func Max[T cmp.Ordered](x T, y T) T {
 	if x >= y {
 		return x
 	}


### PR DESCRIPTION
## Description

Fixes the `lint` job, which has been failing on `master` since roughly May, and fixes every finding the upgraded linter reports rather than configuring them away.

**Related Issues:** <!-- none -->

**Type of Change:**

- [x] Bug Fix
- [x] Refactoring
- [x] Other: CI

### Why lint was failing

The lint job asked setup-go for `"^1.22"`, which is unbounded upward. A runner image bump moved the bundled Go into the 1.26 line, and setup-go resolved the range from the image's tool cache:

```
Setup go version spec ^1.22
Found in cache @ /opt/hostedtoolcache/go/1.26.5/x64
```

golangci-lint was pinned to `v1.64.8`, the final v1 release, built with Go 1.24. golangci-lint only supports toolchains up to the Go version it was built with, so it could not read Go 1.26 export data and reported the mismatch as `typecheck` errors inside dependencies:

```
goupnp@v1.3.0/dcps/internetgateway1/internetgateway1.go:3353:18:
  client.SOAPClient undefined (typecheck)
```

The code compiled the whole time, which is why only `lint` failed while `test` passed on all three platforms. `.github/workflows/ci.yml` was untouched between 2026-02-01 and this branch, and `^1.22` has been there since 2024-07-17, so no commit introduced this and no revert could fix it. It first showed up on #832, a docs-only PR.

### CI changes

- golangci-lint `v1.64.8` → `v2.12.2`, which is built with `go1.26.2`. Action bumped `v6.5.2` → `v9.3.0`, SHA-pinned.
- `GO_VERSION` and `GOLANGCI_LINT_VERSION` are now workflow-level env vars, and all three `setup-go` calls use `GO_VERSION`. Bounding it to the `1.26` line means a new Go release cannot silently change what CI runs. If someone raises `GO_VERSION` past what the pinned linter supports, golangci-lint v2 now fails with an explicit message about the version skew instead of emitting spurious findings in dependencies.
- actionlint is pinned to `v1.7.12` instead of `@latest`, and its version is part of the cache key. The key was previously keyed only on runner OS, so a cached binary was never refreshed when the version changed.

### Findings fixed

v2 reports 36 findings that v1.64.8 never surfaced. All are fixed in code except three in `chain/vendored/apply_transaction.go`, which is upstream go-ethereum code kept close to its original form for diffing; `.golangci.yml` excludes that path from staticcheck.

**errcheck (6).** Three were on write paths where a discarded error means silent data loss:

- `utils.CopyFile` deferred `Close` on the target file. Buffered writes flush at `Close`, so an I/O error there was dropped and `CopyFile` returned `nil` over a truncated copy.
- `RevertReporter.writeHTMLReport` had the same defect writing `revert_report.html`, so a truncated report was logged as a success.
- `TestChain.Close` discarded the trie database `Close`.

Both write paths now report the close error, matching the pattern already used in `coverage.WriteHTMLReport`. `TestChain.Close` discards explicitly, since all eight callers invoke it from a defer during teardown and widening the signature would only move the discard to them. The other two, a Slither cache temp-file removal and a test temp-dir removal, were already documented as deliberate and are now explicit discards.

**govet (4).** Go 1.26's go-fix `inline` analyzer flagged `golang.org/x/exp` wrappers that now have stdlib equivalents. `maps.Clone`, `slices.Clone`, and `cmp.Ordered` are direct swaps. `x/exp/maps.Values` is not: the stdlib version returns an iterator, so `SortedFiles` uses `slices.Collect`. `x/exp` remains a dependency for `constraints.Integer`, which has no stdlib equivalent.

**staticcheck (26).** Mostly the `QF` quickfix family, which staticcheck leaves off by default and golangci-lint enables. Trailing newlines removed from error strings (ST1005), `GetInnerErrorAndExitCode` reordered to return `(int, error)` (ST1008), if/else-if chains converted to tagged switches (QF1003), `strings.ReplaceAll` (QF1004), `fmt.Fprintf` (QF1012), two negated disjunctions rewritten (QF1001), redundant embedded field names dropped from selectors (QF1008). None change behavior.

## Testing

- `golangci-lint v2.12.2` — 0 issues, exit 0
- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — exit 0, every package with tests `ok`, including `fuzzing` (217s)
- `go fmt ./...` and `goimports -l .` — no diff, so CI's format gate passes
- `actionlint` — clean
- `prettier --check` on the changed YAML — clean, which is what CI's format step runs
- `zizmor` on `ci.yml` — 20 findings before and after this branch, so nothing new was introduced

## Additional Context

`GetInnerErrorAndExitCode` is exported from `cmd/exitcodes` and its signature changed. It has one caller, `main.go`, updated here.

## Outstanding TODOs

- [ ] `flake.nix` pins `nixpkgs/nixos-25.05`, which provides golangci-lint 2.1.6 and Go 1.24.9, so `prek` locally runs a different linter than CI. Aligning them means moving the nixpkgs channel, which changes the Go toolchain and `vendorHash`, so it is deliberately not bundled here. The config in this PR was verified against both 2.1.6 and 2.12.2, so local hooks still pass.
- [ ] `chain/vendored/` is excluded from staticcheck only. If that file is ever re-synced from upstream, the exclusion should be revisited.
- [ ] Unrelated and pre-existing: `zizmor` reports 8 high-severity findings on `ci.yml`, and Dependabot reports 16 advisories on `master` (7 critical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
