### PR TITLE
fuzzing: respect minimum mutation rounds

### DIFF
--- a/fuzzing/valuegeneration/generator_mutational.go
+++ b/fuzzing/valuegeneration/generator_mutational.go
@@ -106,7 +106,7 @@ func NewMutationalValueGenerator(config *MutationalValueGeneratorConfig, valueSe
 // MutationalValueGeneratorConfig).
 func (g *MutationalValueGenerator) getMutationParams(inputsLen int) (int, int) {
 	inputIdx := g.randomProvider.Intn(inputsLen)
-	mutationCount := g.randomProvider.Intn(((g.config.MaxMutationRounds - g.config.MinMutationRounds) + 1) + g.config.MinMutationRounds)
+	mutationCount := g.randomProvider.Intn(g.config.MaxMutationRounds-g.config.MinMutationRounds+1) + g.config.MinMutationRounds
 	return inputIdx, mutationCount
 }
 

--- a/fuzzing/valuegeneration/generator_mutational_test.go
+++ b/fuzzing/valuegeneration/generator_mutational_test.go
@@ -1,0 +1,37 @@
+package valuegeneration
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestGetMutationParamsMutationCountRange verifies that mutation counts stay within the configured bounds.
+func TestGetMutationParamsMutationCountRange(t *testing.T) {
+	// A non-zero lower bound exposes the bug hidden by the default minimum of zero.
+	testCases := []struct {
+		name string
+		min  int
+		max  int
+	}{
+		{name: "fixed non-zero range", min: 3, max: 3},
+		{name: "bounded non-zero range", min: 3, max: 5},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			generator := NewMutationalValueGenerator(&MutationalValueGeneratorConfig{
+				MinMutationRounds:          testCase.min,
+				MaxMutationRounds:          testCase.max,
+				RandomValueGeneratorConfig: &RandomValueGeneratorConfig{},
+			}, NewValueSet(), rand.New(rand.NewSource(0)))
+
+			// Sample the deterministic sequence enough times to catch an out-of-range value.
+			for range 100 {
+				_, mutationCount := generator.getMutationParams(1)
+				if mutationCount < testCase.min || mutationCount > testCase.max {
+					t.Fatalf("mutation count %d is outside [%d, %d]", mutationCount, testCase.min, testCase.max)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The mutation count calculation in `getMutationParams` included `MinMutationRounds` in the upper bound passed to `Intn`, but did not add it back to the result. With a non-zero minimum, this allowed fewer mutation rounds than configured, including zero.

Use the configured inclusive range and add deterministic regression coverage for fixed and bounded non-zero ranges.

**Related Issues:** Partially addresses #809 (mutation-count range item only).

**Type of Change:**

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance Improvement
- [x] Tests
- [ ] Other (please describe):

## Testing

- `go test -run TestGetMutationParamsMutationCountRange -count=1 ./fuzzing/valuegeneration`
- `go test -v -count=1 ./fuzzing/valuegeneration`
- `go test -count=1 ./...`
- `go fmt ./...`
- `golangci-lint run --timeout 5m0s`
- `python3 scripts/check_docs.py`
- macOS, Linux/amd64, and Windows/amd64 builds

## Additional Context

This PR only addresses the mutation-count range item from #809. The other code-quality items are unchanged.

## Outstanding TODOs

None for this scoped change.
